### PR TITLE
Fix NullPointer in ModelMapping

### DIFF
--- a/java/src/main/java/com/xxAMIDOxx/xxSTACKSxx/menu/mappers/DomainToDtoMapper.java
+++ b/java/src/main/java/com/xxAMIDOxx/xxSTACKSxx/menu/mappers/DomainToDtoMapper.java
@@ -20,9 +20,9 @@ public class DomainToDtoMapper {
                 UUID.fromString(menu.getRestaurantId()),
                 menu.getName(),
                 menu.getDescription(),
-                menu.getCategories().stream().map(
+                menu.getCategories() != null ? menu.getCategories().stream().map(
                         DomainToDtoMapper::toCategoryDto)
-                        .collect(Collectors.toList()),
+                        .collect(Collectors.toList()) : null,
                 menu.getEnabled());
 
     }
@@ -31,9 +31,9 @@ public class DomainToDtoMapper {
         return new CategoryDTO(category.getId(),
                 category.getName(),
                 category.getDescription(),
-                category.getItems().stream()
+                category.getItems() != null ? category.getItems().stream()
                         .map(DomainToDtoMapper::toItemDto)
-                        .collect(Collectors.toList()));
+                        .collect(Collectors.toList()) : null);
     }
 
     public static ItemDTO toItemDto(Item item) {

--- a/java/src/test/java/com/xxAMIDOxx/xxSTACKSxx/menu/mappers/DomainToDtoMapperTest.java
+++ b/java/src/test/java/com/xxAMIDOxx/xxSTACKSxx/menu/mappers/DomainToDtoMapperTest.java
@@ -9,6 +9,7 @@ import com.xxAMIDOxx.xxSTACKSxx.menu.domain.Item;
 import com.xxAMIDOxx.xxSTACKSxx.menu.domain.Menu;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.UUID;
 
@@ -40,6 +41,67 @@ class DomainToDtoMapperTest {
     assertThat(menuDTO.getDescription()).isEqualTo(description);
     assertThat(menuDTO.getCategories()).isEqualTo(Collections.emptyList());
     assertThat(menuDTO.getEnabled()).isEqualTo(enabled);
+  }
+
+  @Test
+  void menuToMenuDtoWithNullCategories() {
+
+    // Given
+    UUID id = randomUUID();
+    UUID restaurantId = randomUUID();
+    String name = "yyyyyyyy";
+    String description = "xxxxxxxx";
+    Boolean enabled = true;
+
+    Menu menu = new Menu(id.toString(), restaurantId.toString(), name, description,
+            null, enabled);
+
+    // When
+    MenuDTO menuDTO = DomainToDtoMapper.toMenuDto(menu);
+
+    // Then
+    assertThat(menuDTO.getId()).isEqualTo(id);
+    assertThat(menuDTO.getRestaurantId()).isEqualTo(restaurantId);
+    assertThat(menuDTO.getName()).isEqualTo(name);
+    assertThat(menuDTO.getDescription()).isEqualTo(description);
+    assertThat(menuDTO.getCategories()).isNull();
+    assertThat(menuDTO.getEnabled()).isEqualTo(enabled);
+  }
+
+  @Test
+  void menuToMenuDtoWithNullCategoryItems() {
+
+    // Given
+    UUID id = randomUUID();
+    UUID restaurantId = randomUUID();
+    String name = "yyyyyyyy";
+    String description = "xxxxxxxx";
+    Boolean enabled = true;
+
+    UUID categoryId = randomUUID();
+    Category category = new Category(categoryId.toString(),
+            "aaaaaa", "bbbbbb", null);
+
+    Menu menu =
+            new Menu(
+                    id.toString(), restaurantId.toString(), name, description,
+                    Arrays.asList(category), enabled);
+
+    // When
+    MenuDTO menuDTO = DomainToDtoMapper.toMenuDto(menu);
+
+    // Then
+    assertThat(menuDTO.getId()).isEqualTo(id);
+    assertThat(menuDTO.getRestaurantId()).isEqualTo(restaurantId);
+    assertThat(menuDTO.getName()).isEqualTo(name);
+    assertThat(menuDTO.getDescription()).isEqualTo(description);
+    assertThat(menuDTO.getEnabled()).isEqualTo(enabled);
+    assertThat(menuDTO.getCategories().size()).isEqualTo(1);
+    assertThat(menuDTO.getCategories().get(0).getName()).isEqualTo(category.getName());
+    assertThat(menuDTO.getCategories().get(0).getDescription()).isEqualTo(category.getDescription());
+    assertThat(menuDTO.getCategories().get(0).getId()).isEqualTo(category.getId());
+    assertThat(menuDTO.getCategories().get(0).getItems()).isNull();
+
   }
 
   @Test


### PR DESCRIPTION
NullPointerException was occurring in DomainToDtoMapper when a Menu's Categories list is null. 

#### 📲 What

Avoid nullpointer and also do the same for Category when Items is null.
Includes tests to reproduce

#### 🤔 Why

Why it's needed, background context.

#### 🛠 How

<img width="496" alt="Screenshot 2020-07-24 at 09 17 15" src="https://user-images.githubusercontent.com/33906462/88372767-7a5a2680-cd8e-11ea-8e7b-5c0cfa60c4c5.png">

#### 👀 Evidence

Screenshots / external resources / links / etc.
Link to documentation updated with changes impacted in the PR

#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?

