### PR TITLE
2242 - Added OWASP Maven Dependency checker

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -35,6 +35,7 @@
         <junit-jupiter.version>5.6.2</junit-jupiter.version>
         <equals-verifier.version>3.4.1</equals-verifier.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+        <dependency-check-maven.version>5.3.2</dependency-check-maven.version>
     </properties>
 
     <dependencies>
@@ -181,6 +182,28 @@
             </plugin>
         </plugins>
     </reporting>
+
+    <profiles>
+        <profile>
+            <id>owasp-dependency-check</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.owasp</groupId>
+                        <artifactId>dependency-check-maven</artifactId>
+                        <version>5.3.2</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <build>
         <plugins>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -35,7 +35,7 @@
         <junit-jupiter.version>5.6.2</junit-jupiter.version>
         <equals-verifier.version>3.4.1</equals-verifier.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-        <dependency-check-maven.version>5.3.2</dependency-check-maven.version>
+        <owasp-dependency-check-plugin.version>5.3.2</owasp-dependency-check-plugin.version>
     </properties>
 
     <dependencies>
@@ -191,7 +191,7 @@
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-                        <version>5.3.2</version>
+                        <version>${owasp-dependency-check-plugin.version}</version>
                         <executions>
                             <execution>
                                 <goals>


### PR DESCRIPTION
[2242 - Added OWASP Maven Dependency checker]

#### 📲 What

Added OWASP Maven Dependency checker in the pom.xml

#### 🤔 Why

To detect publicly disclosed vulnerabilities contained within a project’s maven dependencies.

#### 🛠 How

OWASP will determine if there is a Common Platform Enumeration (CPE) identifier for a given dependency. If found, it will generate a report linking to the associated CVE entries.
Need to run `mvn clean install -Powasp-dependency-check` as part of each build. This will generate a dependency-check-report.html under the target folder. 

#### 👀 Evidence
![image](https://user-images.githubusercontent.com/67281032/89433862-bc924900-d73a-11ea-8484-42bf077591b4.png)


#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?

