### PR TITLE
Fix: fixes the prod credentials for master build

### DIFF
--- a/build/azDevops/azure/azure-pipelines-javaspring-k8s.yml
+++ b/build/azDevops/azure/azure-pipelines-javaspring-k8s.yml
@@ -374,7 +374,7 @@ stages:
                     namespace: "$(namespace)"
                     deployment_status_timeout: "90s"
                     azure_client_id: "$(azure_client_id)"
-                    azure_client_secret: "$(zure_client_secret)"
+                    azure_client_secret: "$(azure_client_secret)"
                     azure_tenant_id: "$(azure_tenant_id)"
                     azure_subscription_id: "$(azure_subscription_id)"
 
@@ -570,6 +570,6 @@ stages:
                     namespace: "$(namespace)"
                     deployment_status_timeout: "90s"
                     azure_client_id: "$(prod_azure_client_id)"
-                    azure_client_secret: "$(prod_zure_client_secret)"
+                    azure_client_secret: "$(prod_azure_client_secret)"
                     azure_tenant_id: "$(prod_azure_tenant_id)"
                     azure_subscription_id: "$(prod_azure_subscription_id)"

--- a/build/azDevops/azure/azure-pipelines-javaspring-k8s.yml
+++ b/build/azDevops/azure/azure-pipelines-javaspring-k8s.yml
@@ -373,6 +373,10 @@ stages:
                     resource_def_name: "$(resource_def_name)"
                     namespace: "$(namespace)"
                     deployment_status_timeout: "90s"
+                    azure_client_id: "$(azure_client_id)"
+                    azure_client_secret: "$(zure_client_secret)"
+                    azure_tenant_id: "$(azure_tenant_id)"
+                    azure_subscription_id: "$(azure_subscription_id)"
 
   - stage: Prod
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
@@ -565,3 +569,7 @@ stages:
                     resource_def_name: "$(resource_def_name)"
                     namespace: "$(namespace)"
                     deployment_status_timeout: "90s"
+                    azure_client_id: "$(prod_azure_client_id)"
+                    azure_client_secret: "$(prod_zure_client_secret)"
+                    azure_tenant_id: "$(prod_azure_tenant_id)"
+                    azure_subscription_id: "$(prod_azure_subscription_id)"


### PR DESCRIPTION
#### 📲 What

Fixes the master build by passing in credentials properly

#### 🤔 Why

Before the step just assumed a name for the params, now allowing them to be passed in. Prod uses different creds to nonprod.