### PR TITLE
2482 - Make Swagger schema match .net

### DIFF
--- a/java/src/main/java/com/xxAMIDOxx/xxSTACKSxx/menu/api/OpenApiConfiguration.java
+++ b/java/src/main/java/com/xxAMIDOxx/xxSTACKSxx/menu/api/OpenApiConfiguration.java
@@ -4,6 +4,9 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.List;
+import org.springdoc.core.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,17 +14,50 @@ import org.springframework.context.annotation.Configuration;
 public class OpenApiConfiguration {
 
   private static final String PROJECT_URL = "https://github.com/amido/stacks-java";
+  private static final String STACKS_EMAIL = "stacks@amido.com";
+  private static final String SPRING_DOC = "http://springdoc.org";
 
-  /** OAS/Swagger Configuration */
+  /** OAS/Swagger Configuration. */
   @Bean
   public OpenAPI customOpenApi() {
     return new OpenAPI()
+        .servers(List.of(new Server().url("/api/menu")))
         .info(
             new Info()
                 .title("Menu API")
                 .version("1.0")
                 .description("APIs used to interact and manage menus for a restaurant")
-                .contact(new Contact().name("Amido").url(PROJECT_URL).email("stacks@amido.com"))
-                .license(new License().name("Apache 2.0").url("http://springdoc.org")));
+                .contact(new Contact().name("Amido").url(PROJECT_URL).email(STACKS_EMAIL))
+                .license(new License().name("Apache 2.0").url(SPRING_DOC)));
+  }
+
+  /**
+   * Display all the api versions.
+   *
+   * @return list of all the api versions.
+   */
+  @Bean
+  public GroupedOpenApi menuApiAll() {
+    return GroupedOpenApi.builder().group("Menu (all)").pathsToMatch("/**").build();
+  }
+
+  /**
+   * Display Version 1 the api versions.
+   *
+   * @return list of all the V1 api versions.
+   */
+  @Bean
+  public GroupedOpenApi menuApiV1() {
+    return GroupedOpenApi.builder().group("Menu (version 1)").pathsToMatch("/v1/**").build();
+  }
+
+  /**
+   * Display all the V2 api versions.
+   *
+   * @return list of all the V2 api versions.
+   */
+  @Bean
+  public GroupedOpenApi menuApiV2() {
+    return GroupedOpenApi.builder().group("Menu (version 2)").pathsToMatch("/v2/**").build();
   }
 }

--- a/java/src/main/java/com/xxAMIDOxx/xxSTACKSxx/menu/api/v2/QueryMenuControllerV2.java
+++ b/java/src/main/java/com/xxAMIDOxx/xxSTACKSxx/menu/api/v2/QueryMenuControllerV2.java
@@ -1,0 +1,53 @@
+package com.xxAMIDOxx.xxSTACKSxx.menu.api.v2;
+
+import com.xxAMIDOxx.xxSTACKSxx.core.api.dto.ErrorResponse;
+import com.xxAMIDOxx.xxSTACKSxx.menu.api.v1.dto.response.MenuDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequestMapping("/v2/menu")
+public interface QueryMenuControllerV2 {
+
+  @GetMapping(value = "/{id}", produces = "application/json; charset=utf-8")
+  @Operation(
+      tags = "Menu",
+      summary = "Get a menu",
+      description =
+          "By passing the menu id, you can get access to available categories and items in the menu",
+      operationId = "GetMenuV2",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Menu",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = MenuDTO.class))),
+        @ApiResponse(
+            responseCode = "404",
+            description = "Menu Not Found",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Bad Request",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ErrorResponse.class)))
+      })
+  ResponseEntity<MenuDTO> getMenu(
+      @PathVariable(name = "id") UUID id,
+      @Parameter(hidden = true) @RequestAttribute("CorrelationId") String correlationId);
+}

--- a/java/src/main/java/com/xxAMIDOxx/xxSTACKSxx/menu/api/v2/impl/QueryMenuControllerImplV2.java
+++ b/java/src/main/java/com/xxAMIDOxx/xxSTACKSxx/menu/api/v2/impl/QueryMenuControllerImplV2.java
@@ -1,0 +1,38 @@
+package com.xxAMIDOxx.xxSTACKSxx.menu.api.v2.impl;
+
+import com.xxAMIDOxx.xxSTACKSxx.menu.api.v1.dto.response.MenuDTO;
+import com.xxAMIDOxx.xxSTACKSxx.menu.api.v2.QueryMenuControllerV2;
+import com.xxAMIDOxx.xxSTACKSxx.menu.commands.MenuCommand;
+import com.xxAMIDOxx.xxSTACKSxx.menu.commands.OperationCode;
+import com.xxAMIDOxx.xxSTACKSxx.menu.domain.Menu;
+import com.xxAMIDOxx.xxSTACKSxx.menu.exception.MenuNotFoundException;
+import com.xxAMIDOxx.xxSTACKSxx.menu.mappers.DomainToDtoMapper;
+import com.xxAMIDOxx.xxSTACKSxx.menu.service.MenuQueryService;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class QueryMenuControllerImplV2 implements QueryMenuControllerV2 {
+
+  private DomainToDtoMapper mapper;
+
+  private MenuQueryService menuQueryService;
+
+  public QueryMenuControllerImplV2(DomainToDtoMapper mapper, MenuQueryService menuQueryService) {
+    this.mapper = mapper;
+    this.menuQueryService = menuQueryService;
+  }
+
+  @Override
+  public ResponseEntity<MenuDTO> getMenu(UUID id, String correlationId) {
+    Menu menu =
+        this.menuQueryService
+            .findById(id)
+            .orElseThrow(
+                () ->
+                    new MenuNotFoundException(
+                        new MenuCommand(OperationCode.GET_MENU_BY_ID, correlationId, id)));
+    return ResponseEntity.ok(mapper.toMenuDto(menu));
+  }
+}

--- a/java/src/main/resources/application.yml
+++ b/java/src/main/resources/application.yml
@@ -22,7 +22,12 @@ springdoc:
     disable-swagger-default-url: true
     display-operation-id: true
     path: /swagger/index.html # TODO: Swagger keeps redirecting, it'd be good to stop it if possible
-  packagesToScan: com.xxAMIDOxx.xxSTACKSxx.menu.api.v1
+  packagesToScan: com.xxAMIDOxx.xxSTACKSxx.menu.api
+  api-docs:
+    groups:
+      enabled: true
+    enabled: true
+    path: /swagger/oas-json
 
 azure:
   cosmosdb:

--- a/java/src/test/java/com/xxAMIDOxx/xxSTACKSxx/menu/api/v2/impl/QueryMenuControllerImplV2Test.java
+++ b/java/src/test/java/com/xxAMIDOxx/xxSTACKSxx/menu/api/v2/impl/QueryMenuControllerImplV2Test.java
@@ -1,0 +1,73 @@
+package com.xxAMIDOxx.xxSTACKSxx.menu.api.v2.impl;
+
+import static com.xxAMIDOxx.xxSTACKSxx.menu.domain.MenuHelper.createMenu;
+import static com.xxAMIDOxx.xxSTACKSxx.util.TestHelper.getBaseURL;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+import com.microsoft.azure.spring.autoconfigure.cosmosdb.CosmosAutoConfiguration;
+import com.microsoft.azure.spring.autoconfigure.cosmosdb.CosmosDbRepositoriesAutoConfiguration;
+import com.xxAMIDOxx.xxSTACKSxx.menu.api.v1.dto.response.MenuDTO;
+import com.xxAMIDOxx.xxSTACKSxx.menu.domain.Menu;
+import com.xxAMIDOxx.xxSTACKSxx.menu.mappers.DomainToDtoMapper;
+import com.xxAMIDOxx.xxSTACKSxx.menu.repository.MenuRepository;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@EnableAutoConfiguration(
+    exclude = {CosmosDbRepositoriesAutoConfiguration.class, CosmosAutoConfiguration.class})
+@Tag("Integration")
+class QueryMenuControllerImplV2Test {
+
+  private final String GET_MENU_BY_ID = "%s/v2/menu/%s";
+
+  @LocalServerPort private int port;
+
+  @Autowired private TestRestTemplate testRestTemplate;
+
+  @MockBean private MenuRepository menuRepository;
+
+  @Test
+  void getMenuById() {
+    // Given
+    Menu menu = createMenu(0);
+    MenuDTO expectedResponse = DomainToDtoMapper.toMenuDto(menu);
+
+    when(menuRepository.findById(menu.getId())).thenReturn(Optional.of(menu));
+
+    // When
+    var response =
+        this.testRestTemplate.getForEntity(
+            String.format(GET_MENU_BY_ID, getBaseURL(port), menu.getId()), MenuDTO.class);
+
+    // Then
+    then(response.getBody()).isEqualTo(expectedResponse);
+  }
+
+  @Test
+  void getMenuByInvalidId() {
+    // Given
+    Menu menu = createMenu(0);
+
+    when(menuRepository.findById(eq(menu.getId()))).thenReturn(Optional.of(menu));
+
+    // When
+    var response =
+        this.testRestTemplate.getForEntity(
+            String.format(GET_MENU_BY_ID, getBaseURL(port), UUID.randomUUID()), MenuDTO.class);
+
+    // Then
+    then(response.getStatusCode()).isEqualTo(NOT_FOUND);
+  }
+}


### PR DESCRIPTION
2482 - Make Swagger schema match .net

#### 📲 What

1.  Add version tags
2. change the servers url


#### 🤔 Why

Why it's needed, background context.

#### 🛠 How

More in-depth discussion of the change or implementation.

#### 👀 Evidence

Screenshots / external resources / links / etc.
Link to documentation updated with changes impacted in the PR

#### 🕵️ How to test

Notes for QA
Swagger JSON is available here: http://localhost:9000/swagger/oas.json
UI Swagger here: http://localhost:9000/swagger/index.html

![image](https://user-images.githubusercontent.com/67281032/90622631-49460800-e20d-11ea-951b-cbd6ec75a757.png)


#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
