### PR TITLE
2355 - Enable CheckStyle and fmt to be run as separate plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The Java source code will automatically be reformatted to comply with [Google Ja
 You can override the settings in the codebase, for example:<br />
 ```//@formatter:off```<br />
 ```manually formatted code```<br />
-```///@formatter:on````<br />
+```///@formatter:on```<br />
 
 ###### Validate the formatting
 ```

--- a/api-tests/pom.xml
+++ b/api-tests/pom.xml
@@ -23,6 +23,11 @@
         <pact.broker.url></pact.broker.url>
         <pact.broker.token></pact.broker.token>
         <owasp-dependency-check-plugin.version>5.3.2</owasp-dependency-check-plugin.version>
+        <fmt-maven-plugin.version>2.10</fmt-maven-plugin.version>
+        <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
+        <puppycrawl-tools-checkstyle.version>8.35</puppycrawl-tools-checkstyle.version>
+        <spotbugs-maven-plugin.version>4.0.4</spotbugs-maven-plugin.version>
+        <spotbugs.version>4.1.1</spotbugs.version>
     </properties>
 
     <dependencies>
@@ -295,6 +300,59 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.coveo</groupId>
+                <artifactId>fmt-maven-plugin</artifactId>
+                <version>${fmt-maven-plugin.version}</version>
+                <configuration>
+                    <displayFiles>false</displayFiles>
+                    <verbose>true</verbose>
+                    <filesNamePattern>.*\.java</filesNamePattern>
+                    <additionalSourceDirectories/>
+                    <skip>false</skip>
+                    <skipSortingImports>false</skipSortingImports>
+                    <style>google</style>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>${maven-checkstyle-plugin.version}</version>
+                <dependencies>
+                    <!--Specify Dependent checkstyle Edition-->
+                    <dependency>
+                        <groupId>com.puppycrawl.tools</groupId>
+                        <artifactId>checkstyle</artifactId>
+                        <version>${puppycrawl-tools-checkstyle.version}</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <configLocation>google_checks.xml</configLocation>
+                    <encoding>UTF-8</encoding>
+                    <consoleOutput>true</consoleOutput>
+                    <failsOnError>true</failsOnError>
+                    <linkXRef>false</linkXRef>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>validate</id>
+                        <phase>validate</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>${spotbugs-maven-plugin.version}</version>
+                <dependencies>
+                    <!-- overwrite dependency on spotbugs if you want to specify the version of spotbugs -->
+                    <dependency>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs</artifactId>
+                        <version>${spotbugs.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/CucumberTestSuite.java
+++ b/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/CucumberTestSuite.java
@@ -8,16 +8,14 @@ import org.junit.runner.RunWith;
 
 @RunWith(CucumberWithSerenity.class)
 @CucumberOptions(
-        plugin = {"pretty", "html:target/cucumber"},
-        features = "src/test/resources/features",
-        tags = "(not @Ignore) and (@Smoke or @Regression or @Functional)"
-)
+    plugin = {"pretty", "html:target/cucumber"},
+    features = "src/test/resources/features",
+    tags = "(not @Ignore) and (@Smoke or @Regression or @Functional)")
 public class CucumberTestSuite {
 
-    @BeforeClass
-    public static void setup() {
-        System.out.println("Delete all data from previous automated test");
-        Hooks.deleteAllMenusFromPreviousRun();
-    }
-
+  @BeforeClass
+  public static void setup() {
+    System.out.println("Delete all data from previous automated test");
+    Hooks.deleteAllMenusFromPreviousRun();
+  }
 }

--- a/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/DeleteAllMenusCleanUp.java
+++ b/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/DeleteAllMenusCleanUp.java
@@ -6,9 +6,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(CucumberWithSerenity.class)
 @CucumberOptions(
-        plugin = {"pretty", "html:target/cucumber"},
-        features = "src/test/resources/features",
-        tags = "@DeleteAllMenusCleanUp"
-
-)
+    plugin = {"pretty", "html:target/cucumber"},
+    features = "src/test/resources/features",
+    tags = "@DeleteAllMenusCleanUp")
 public class DeleteAllMenusCleanUp {}

--- a/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/ExceptionMessages.java
+++ b/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/ExceptionMessages.java
@@ -1,25 +1,26 @@
 package com.xxAMIDOxx.xxSTACKSxx.api;
 
 public enum ExceptionMessages {
+  MENU_ALREADY_EXISTS(
+      "A Menu with the name '(.*)' already exists for the restaurant with id '(.*)'."),
+  MENU_DOES_NOT_EXIST("A menu with id '(.*)' does not exist."),
 
-    MENU_ALREADY_EXISTS("A Menu with the name '(.*)' already exists for the restaurant with id '(.*)'."),
-    MENU_DOES_NOT_EXIST("A menu with id '(.*)' does not exist."),
+  CATEGORY_DOES_NOT_EXIST("A category with the id '(.*)' does not exist for menu with id '(.*)'."),
+  CATEGORY_ALREADY_EXISTS(
+      "A category with the name '(.*)' already exists for the menu with id '(.*)'."),
 
-    CATEGORY_DOES_NOT_EXIST("A category with the id '(.*)' does not exist for menu with id '(.*)'."),
-    CATEGORY_ALREADY_EXISTS("A category with the name '(.*)' already exists for the menu with id '(.*)'."),
+  ITEM_ALREADY_EXISTS(
+      "An item with the name '(.*)' already exists for the category '(.*)' in menu with id '(.*)'."),
+  ITEM_DOES_NOT_EXIST(
+      "An item with the id '(.*)' does not exists for category with the id '(.*)' and for menu with id '(.*)'.");
 
+  private final String message;
 
-    ITEM_ALREADY_EXISTS("An item with the name '(.*)' already exists for the category '(.*)' in menu with id '(.*)'."),
-    ITEM_DOES_NOT_EXIST("An item with the id '(.*)' does not exists for category with the id '(.*)' and for menu with id '(.*)'.");
+  ExceptionMessages(String message) {
+    this.message = message;
+  }
 
-    private final String message;
-
-    ExceptionMessages(String message) {
-        this.message = message;
-    }
-
-    public String getMessage() {
-        return message;
-    }
-
+  public String getMessage() {
+    return message;
+  }
 }

--- a/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/WebServiceEndPoints.java
+++ b/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/WebServiceEndPoints.java
@@ -1,20 +1,20 @@
 package com.xxAMIDOxx.xxSTACKSxx.api;
 
 public enum WebServiceEndPoints {
-    BASE_URL(System.getenv("BASE_URL")),
-    CATEGORY("/category"),
-    STATUS("/health"),
-    MENU("/v1/menu"),
-    MENU_V2("/v2/menu"),
-    ITEMS("/items");
+  BASE_URL(System.getenv("BASE_URL")),
+  CATEGORY("/category"),
+  STATUS("/health"),
+  MENU("/v1/menu"),
+  MENU_V2("/v2/menu"),
+  ITEMS("/items");
 
-    private final String url;
+  private final String url;
 
-    WebServiceEndPoints(String url) {
-        this.url = url;
-    }
+  WebServiceEndPoints(String url) {
+    this.url = url;
+  }
 
-    public String getUrl() {
-        return url;
-    }
+  public String getUrl() {
+    return url;
+  }
 }

--- a/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/category/CategoryActions.java
+++ b/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/category/CategoryActions.java
@@ -1,13 +1,13 @@
 package com.xxAMIDOxx.xxSTACKSxx.api.category;
 
 import com.xxAMIDOxx.xxSTACKSxx.api.models.Category;
-
 import java.util.ArrayList;
 import java.util.Map;
 
 public class CategoryActions {
 
-    public static Category mapToCategory(Map<String, String> properties, String id) {
-        return new Category(id, properties.get("name"), properties.get("description"), new ArrayList<>());
-    }
+  public static Category mapToCategory(Map<String, String> properties, String id) {
+    return new Category(
+        id, properties.get("name"), properties.get("description"), new ArrayList<>());
+  }
 }

--- a/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/category/CategoryRequests.java
+++ b/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/category/CategoryRequests.java
@@ -6,36 +6,45 @@ import net.thucydides.core.annotations.Step;
 
 public class CategoryRequests {
 
-    String menuUrl = WebServiceEndPoints.BASE_URL.getUrl() + WebServiceEndPoints.MENU.getUrl();
+  String menuUrl = WebServiceEndPoints.BASE_URL.getUrl() + WebServiceEndPoints.MENU.getUrl();
 
-    @Step("Create a new category")
-    public void createCategory(String body, String menuID) {
-        SerenityRest.given()
-                .contentType("application/json")
-                .header("Content-Type", "application/json")
-                .body(body)
-                .when()
-                .post(menuUrl.concat("/").concat(menuID).concat(WebServiceEndPoints.CATEGORY.getUrl()));
-    }
+  @Step("Create a new category")
+  public void createCategory(String body, String menuID) {
+    SerenityRest.given()
+        .contentType("application/json")
+        .header("Content-Type", "application/json")
+        .body(body)
+        .when()
+        .post(menuUrl.concat("/").concat(menuID).concat(WebServiceEndPoints.CATEGORY.getUrl()));
+  }
 
-    @Step("Update the category")
-    public void updateCategory(String body, String menuID, String categoryID) {
-        SerenityRest.given()
-                .contentType("application/json")
-                .header("Content-Type", "application/json")
-                .body(body)
-                .when()
-                .put(menuUrl.concat("/").concat(menuID).concat(WebServiceEndPoints.CATEGORY.getUrl())
-                        .concat("/").concat(categoryID));
-    }
+  @Step("Update the category")
+  public void updateCategory(String body, String menuID, String categoryID) {
+    SerenityRest.given()
+        .contentType("application/json")
+        .header("Content-Type", "application/json")
+        .body(body)
+        .when()
+        .put(
+            menuUrl
+                .concat("/")
+                .concat(menuID)
+                .concat(WebServiceEndPoints.CATEGORY.getUrl())
+                .concat("/")
+                .concat(categoryID));
+  }
 
-    @Step("Delete the category")
-    public void deleteTheCategory(String menuID, String categoryID) {
-        SerenityRest.given()
-                .contentType("application/json")
-                .when()
-                .delete(menuUrl.concat("/").concat(menuID)
-                        .concat(WebServiceEndPoints.CATEGORY.getUrl())
-                        .concat("/").concat(categoryID));
-    }
+  @Step("Delete the category")
+  public void deleteTheCategory(String menuID, String categoryID) {
+    SerenityRest.given()
+        .contentType("application/json")
+        .when()
+        .delete(
+            menuUrl
+                .concat("/")
+                .concat(menuID)
+                .concat(WebServiceEndPoints.CATEGORY.getUrl())
+                .concat("/")
+                .concat(categoryID));
+  }
 }

--- a/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/item/ItemActions.java
+++ b/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/item/ItemActions.java
@@ -1,15 +1,15 @@
 package com.xxAMIDOxx.xxSTACKSxx.api.item;
 
 import com.xxAMIDOxx.xxSTACKSxx.api.models.Item;
-
 import java.util.Map;
 
 public class ItemActions {
-    public static Item mapToItem(Map<String, String> properties, String itemId) {
-        return new Item(itemId,
-                properties.get("name"),
-                properties.get("description"),
-                Double.valueOf(properties.get("price")),
-                Boolean.parseBoolean(properties.get("available")));
-    }
+  public static Item mapToItem(Map<String, String> properties, String itemId) {
+    return new Item(
+        itemId,
+        properties.get("name"),
+        properties.get("description"),
+        Double.valueOf(properties.get("price")),
+        Boolean.parseBoolean(properties.get("available")));
+  }
 }

--- a/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/item/ItemRequests.java
+++ b/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/item/ItemRequests.java
@@ -6,38 +6,56 @@ import net.thucydides.core.annotations.Step;
 
 public class ItemRequests {
 
-    String menuUrl = WebServiceEndPoints.BASE_URL.getUrl().concat(WebServiceEndPoints.MENU.getUrl());
+  String menuUrl = WebServiceEndPoints.BASE_URL.getUrl().concat(WebServiceEndPoints.MENU.getUrl());
 
-    @Step("Create a new item")
-    public void createItem(String body, String menuID, String categoryID) {
-        SerenityRest.given()
-                .contentType("application/json")
-                .body(body)
-                .when()
-                .post(menuUrl.concat("/").concat(menuID)
-                        .concat(WebServiceEndPoints.CATEGORY.getUrl()).concat("/").concat(categoryID)
-                        .concat(WebServiceEndPoints.ITEMS.getUrl()));
+  @Step("Create a new item")
+  public void createItem(String body, String menuID, String categoryID) {
+    SerenityRest.given()
+        .contentType("application/json")
+        .body(body)
+        .when()
+        .post(
+            menuUrl
+                .concat("/")
+                .concat(menuID)
+                .concat(WebServiceEndPoints.CATEGORY.getUrl())
+                .concat("/")
+                .concat(categoryID)
+                .concat(WebServiceEndPoints.ITEMS.getUrl()));
+  }
 
-    }
+  @Step("Update the item")
+  public void updateItem(String body, String menuID, String categoryID, String itemID) {
+    SerenityRest.given()
+        .contentType("application/json")
+        .body(body)
+        .when()
+        .put(
+            menuUrl
+                .concat("/")
+                .concat(menuID)
+                .concat(WebServiceEndPoints.CATEGORY.getUrl())
+                .concat("/")
+                .concat(categoryID)
+                .concat(WebServiceEndPoints.ITEMS.getUrl())
+                .concat("/")
+                .concat(itemID));
+  }
 
-    @Step("Update the item")
-    public void updateItem(String body, String menuID, String categoryID, String itemID) {
-        SerenityRest.given()
-                .contentType("application/json")
-                .body(body)
-                .when()
-                .put(menuUrl.concat("/").concat(menuID)
-                        .concat(WebServiceEndPoints.CATEGORY.getUrl()).concat("/").concat(categoryID)
-                        .concat(WebServiceEndPoints.ITEMS.getUrl()).concat("/").concat(itemID));
-    }
-
-    @Step("Delete the item")
-    public void deleteTheItem(String menuID, String categoryID, String itemID) {
-        SerenityRest.given()
-                .contentType("application/json")
-                .when()
-                .delete(menuUrl.concat("/").concat(menuID)
-                        .concat(WebServiceEndPoints.CATEGORY.getUrl()).concat("/").concat(categoryID)
-                        .concat(WebServiceEndPoints.ITEMS.getUrl()).concat("/").concat(itemID));
-    }
+  @Step("Delete the item")
+  public void deleteTheItem(String menuID, String categoryID, String itemID) {
+    SerenityRest.given()
+        .contentType("application/json")
+        .when()
+        .delete(
+            menuUrl
+                .concat("/")
+                .concat(menuID)
+                .concat(WebServiceEndPoints.CATEGORY.getUrl())
+                .concat("/")
+                .concat(categoryID)
+                .concat(WebServiceEndPoints.ITEMS.getUrl())
+                .concat("/")
+                .concat(itemID));
+  }
 }

--- a/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/menu/MenuActions.java
+++ b/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/menu/MenuActions.java
@@ -1,84 +1,83 @@
 package com.xxAMIDOxx.xxSTACKSxx.api.menu;
 
+import static net.serenitybdd.rest.SerenityRest.lastResponse;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.xxAMIDOxx.xxSTACKSxx.api.ExceptionMessages;
 import com.xxAMIDOxx.xxSTACKSxx.api.models.Menu;
 import io.restassured.response.Response;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
-import static net.serenitybdd.rest.SerenityRest.lastResponse;
-
 public class MenuActions {
 
-    private final static Logger LOGGER = LoggerFactory.getLogger(MenuActions.class);
-    private final static ObjectMapper objectMapper = new ObjectMapper();
+  private static final Logger LOGGER = LoggerFactory.getLogger(MenuActions.class);
+  private static final ObjectMapper objectMapper = new ObjectMapper();
 
+  public String getIdOfLastCreatedObject() {
+    return String.valueOf(toJson(lastResponse().getBody().prettyPrint()).get("id"));
+  }
 
-    public String getIdOfLastCreatedObject() {
-        return String.valueOf(toJson(lastResponse().getBody().prettyPrint()).get("id"));
+  public String getRestaurantIdOfLastCreatedMenu() {
+    return String.valueOf(toJson(lastResponse().getBody().prettyPrint()).get("restaurantId"));
+  }
+
+  public void check_exception_message(ExceptionMessages parameter, Response response) {
+    JSONObject js = toJson(response.getBody().prettyPrint());
+    String message = parameter.getMessage();
+
+    Assert.assertTrue(js.get("description").toString().matches(message));
+  }
+
+  public static JSONObject toJson(String stringToParse) {
+    JSONObject jsonObject = null;
+    try {
+      jsonObject = new JSONObject(stringToParse);
+    } catch (JSONException err) {
+      LOGGER.warn(err.getMessage());
     }
+    return jsonObject;
+  }
 
-    public String getRestaurantIdOfLastCreatedMenu() {
-        return String.valueOf(toJson(lastResponse().getBody().prettyPrint()).get("restaurantId"));
+  public Menu responseToMenu(Response response) {
+    Menu actualMenu = null;
+    try {
+      actualMenu = objectMapper.readValue(response.body().print(), Menu.class);
+    } catch (JsonProcessingException e) {
+      e.printStackTrace();
     }
+    return actualMenu;
+  }
 
-    public void check_exception_message(ExceptionMessages parameter, Response response) {
-        JSONObject js = toJson(response.getBody().prettyPrint());
-        String message = parameter.getMessage();
+  public static Menu mapToMenu(Map<String, String> properties, String id) {
+    return new Menu(
+        id,
+        UUID.fromString(properties.get("tenantId")),
+        properties.get("name"),
+        properties.get("description"),
+        null,
+        Boolean.parseBoolean(properties.get("enabled")));
+  }
 
-        Assert.assertTrue(js.get("description").toString().matches(message));
+  public static String createUrlWithCriteria(List<List<String>> data) {
+    StringBuilder finalPath = new StringBuilder();
+    for (int i = 0; i < data.size(); i++) {
+
+      String parameter = data.get(i).get(0);
+      String value = data.get(i).get(1);
+
+      finalPath.append(parameter).append("=").append(value);
+      if (i != data.size() - 1) {
+        finalPath.append("&");
+      }
     }
-
-
-    public static JSONObject toJson(String stringToParse) {
-        JSONObject jsonObject = null;
-        try {
-            jsonObject = new JSONObject(stringToParse);
-        } catch (JSONException err) {
-            LOGGER.warn(err.getMessage());
-        }
-        return jsonObject;
-    }
-
-
-    public Menu responseToMenu(Response response) {
-        Menu actualMenu = null;
-        try {
-            actualMenu = objectMapper.readValue(response.body().print(), Menu.class);
-        } catch (JsonProcessingException e) {
-            e.printStackTrace();
-        }
-        return actualMenu;
-    }
-
-
-    public static Menu mapToMenu(Map<String, String> properties, String id) {
-        return new Menu(id, UUID.fromString(properties.get("tenantId")), properties.get("name"),
-                properties.get("description"), null, Boolean.parseBoolean(properties.get("enabled")));
-    }
-
-
-    public static String createUrlWithCriteria(List<List<String>> data) {
-        StringBuilder finalPath = new StringBuilder();
-        for (int i = 0; i < data.size(); i++) {
-
-            String parameter = data.get(i).get(0);
-            String value = data.get(i).get(1);
-
-            finalPath.append(parameter).append("=").append(value);
-            if (i != data.size() - 1) {
-                finalPath.append("&");
-            }
-        }
-        return finalPath.toString();
-    }
+    return finalPath.toString();
+  }
 }

--- a/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/menu/MenuRequests.java
+++ b/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/menu/MenuRequests.java
@@ -6,46 +6,38 @@ import net.thucydides.core.annotations.Step;
 
 public class MenuRequests {
 
-    private static String menuUrl = WebServiceEndPoints.BASE_URL.getUrl().concat(WebServiceEndPoints.MENU.getUrl());
+  private static String menuUrl =
+      WebServiceEndPoints.BASE_URL.getUrl().concat(WebServiceEndPoints.MENU.getUrl());
 
-    @Step("Create a new menu")
-    public void createMenu(String body) {
-        SerenityRest.given()
-                .contentType("application/json")
-                .body(body)
-                .when()
-                .post(menuUrl);
+  @Step("Create a new menu")
+  public void createMenu(String body) {
+    SerenityRest.given().contentType("application/json").body(body).when().post(menuUrl);
+  }
 
-    }
+  @Step("Update the menu")
+  public void updateMenu(String body, String id) {
+    SerenityRest.given().contentType("application/json").body(body).when().put(menuUrl + "/" + id);
+  }
 
-    @Step("Update the menu")
-    public void updateMenu(String body, String id) {
-        SerenityRest.given()
-                .contentType("application/json")
-                .body(body)
-                .when()
-                .put(menuUrl + "/" + id);
-    }
+  @Step("Get the menu")
+  public void getMenu(String id) {
+    SerenityRest.get(menuUrl.concat("/").concat(id));
+  }
 
-    @Step("Get the menu")
-    public void getMenu(String id) {
-        SerenityRest.get(menuUrl.concat("/").concat(id));
-    }
+  @Step("Delete the menu")
+  public static void deleteTheMenu(String id) {
+    SerenityRest.given()
+        .contentType("application/json")
+        .when()
+        .delete(menuUrl.concat("/").concat(id));
+  }
 
-    @Step("Delete the menu")
-    public static void deleteTheMenu(String id) {
-        SerenityRest.given()
-                .contentType("application/json")
-                .when()
-                .delete(menuUrl.concat("/").concat(id));
-    }
+  @Step("Get all menus")
+  public void getAllMenus() {
+    SerenityRest.get(menuUrl);
+  }
 
-    @Step("Get all menus")
-    public void getAllMenus() {
-        SerenityRest.get(menuUrl);
-    }
-
-    public static void getMenusBySearchTerm(String searchTerm) {
-        SerenityRest.get(menuUrl.concat("?searchTerm=").concat(searchTerm));
-    }
+  public static void getMenusBySearchTerm(String searchTerm) {
+    SerenityRest.get(menuUrl.concat("?searchTerm=").concat(searchTerm));
+  }
 }

--- a/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/models/Category.java
+++ b/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/models/Category.java
@@ -1,64 +1,62 @@
 package com.xxAMIDOxx.xxSTACKSxx.api.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
 public class Category {
 
-    @JsonProperty("id")
-    private String id;
+  @JsonProperty("id")
+  private String id;
 
-    @JsonProperty("name")
-    private String name;
+  @JsonProperty("name")
+  private String name;
 
-    @JsonProperty("description")
-    private String description;
+  @JsonProperty("description")
+  private String description;
 
-    @JsonProperty("items")
-    private List<Item> items = new ArrayList<>();
+  @JsonProperty("items")
+  private List<Item> items = new ArrayList<>();
 
-    public Category() {
-    }
+  public Category() {}
 
-    public Category(String id, String name, String description, List<Item> items) {
-        this.id = id;
-        this.name = name;
-        this.description = description;
-        this.items = items;
-    }
+  public Category(String id, String name, String description, List<Item> items) {
+    this.id = id;
+    this.name = name;
+    this.description = description;
+    this.items = items;
+  }
 
-    public String getId() {
-        return id;
-    }
+  public String getId() {
+    return id;
+  }
 
-    public String getName() {
-        return name;
-    }
+  public String getName() {
+    return name;
+  }
 
-    public String getDescription() {
-        return description;
-    }
+  public String getDescription() {
+    return description;
+  }
 
-    public List<Item> getItems() {
-        return items;
-    }
+  public List<Item> getItems() {
+    return items;
+  }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Category category = (Category) o;
-        return Objects.equals(id, category.id) &&
-                Objects.equals(name, category.name) &&
-                Objects.equals(description, category.description) &&
-                Objects.equals(items, category.items);
-    }
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Category category = (Category) o;
+    return Objects.equals(id, category.id)
+        && Objects.equals(name, category.name)
+        && Objects.equals(description, category.description)
+        && Objects.equals(items, category.items);
+  }
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(id, name, description, items);
-    }
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, name, description, items);
+  }
 }

--- a/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/models/Item.java
+++ b/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/models/Item.java
@@ -1,51 +1,49 @@
 package com.xxAMIDOxx.xxSTACKSxx.api.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.Objects;
 
 public class Item {
 
-    @JsonProperty("id")
-    private String id;
+  @JsonProperty("id")
+  private String id;
 
-    @JsonProperty("name")
-    private String name;
+  @JsonProperty("name")
+  private String name;
 
-    @JsonProperty("description")
-    private String description;
+  @JsonProperty("description")
+  private String description;
 
-    @JsonProperty("price")
-    private Double price;
+  @JsonProperty("price")
+  private Double price;
 
-    @JsonProperty("available")
-    private Boolean available;
+  @JsonProperty("available")
+  private Boolean available;
 
-    public Item() {
-    }
+  public Item() {}
 
-    public Item(String id, String name, String description, Double price, Boolean available) {
-        this.id = id;
-        this.name = name;
-        this.description = description;
-        this.price = price;
-        this.available = available;
-    }
+  public Item(String id, String name, String description, Double price, Boolean available) {
+    this.id = id;
+    this.name = name;
+    this.description = description;
+    this.price = price;
+    this.available = available;
+  }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Item item = (Item) o;
-        return Objects.equals(id, item.id) &&
-                Objects.equals(name, item.name) &&
-                Objects.equals(description, item.description) &&
-                Objects.equals(price, item.price) &&
-                Objects.equals(available, item.available);
-    }
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Item item = (Item) o;
+    return Objects.equals(id, item.id)
+        && Objects.equals(name, item.name)
+        && Objects.equals(description, item.description)
+        && Objects.equals(price, item.price)
+        && Objects.equals(available, item.available);
+  }
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(id, name, description, price, available);
-    }
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, name, description, price, available);
+  }
 }

--- a/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/models/Menu.java
+++ b/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/models/Menu.java
@@ -1,83 +1,86 @@
 package com.xxAMIDOxx.xxSTACKSxx.api.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
 public class Menu {
 
-    @JsonProperty("id")
-    private String id;
+  @JsonProperty("id")
+  private String id;
 
-    @JsonProperty("restaurantId")
-    private UUID restaurantId;
+  @JsonProperty("restaurantId")
+  private UUID restaurantId;
 
-    @JsonProperty("name")
-    private String name;
+  @JsonProperty("name")
+  private String name;
 
-    @JsonProperty("description")
-    private String description;
+  @JsonProperty("description")
+  private String description;
 
-    @JsonProperty("categories")
-    private List<Category> categories;
+  @JsonProperty("categories")
+  private List<Category> categories;
 
-    @JsonProperty("enabled")
-    private Boolean enabled;
+  @JsonProperty("enabled")
+  private Boolean enabled;
 
-    public Menu() {
-    }
+  public Menu() {}
 
-    public Menu(String id, UUID restaurantId, String name, String description, List<Category> categories, Boolean enabled) {
-        this.id = id;
-        this.restaurantId = restaurantId;
-        this.name = name;
-        this.description = description;
-        this.categories = categories;
-        this.enabled = enabled;
-    }
+  public Menu(
+      String id,
+      UUID restaurantId,
+      String name,
+      String description,
+      List<Category> categories,
+      Boolean enabled) {
+    this.id = id;
+    this.restaurantId = restaurantId;
+    this.name = name;
+    this.description = description;
+    this.categories = categories;
+    this.enabled = enabled;
+  }
 
-    public String getId() {
-        return id;
-    }
+  public String getId() {
+    return id;
+  }
 
-    public UUID getRestaurantId() {
-        return restaurantId;
-    }
+  public UUID getRestaurantId() {
+    return restaurantId;
+  }
 
-    public String getName() {
-        return name;
-    }
+  public String getName() {
+    return name;
+  }
 
-    public String getDescription() {
-        return description;
-    }
+  public String getDescription() {
+    return description;
+  }
 
-    public List<Category> getCategories() {
-        return categories;
-    }
+  public List<Category> getCategories() {
+    return categories;
+  }
 
-    public Boolean getEnabled() {
-        return enabled;
-    }
+  public Boolean getEnabled() {
+    return enabled;
+  }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Menu menu = (Menu) o;
+    return Objects.equals(id, menu.id)
+        && Objects.equals(restaurantId, menu.restaurantId)
+        && Objects.equals(name, menu.name)
+        && Objects.equals(description, menu.description)
+        && Objects.equals(categories, menu.categories)
+        && Objects.equals(enabled, menu.enabled);
+  }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Menu menu = (Menu) o;
-        return Objects.equals(id, menu.id) &&
-                Objects.equals(restaurantId, menu.restaurantId) &&
-                Objects.equals(name, menu.name) &&
-                Objects.equals(description, menu.description) &&
-                Objects.equals(categories, menu.categories) &&
-                Objects.equals(enabled, menu.enabled);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(id, restaurantId, name, description, categories, enabled);
-    }
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, restaurantId, name, description, categories, enabled);
+  }
 }

--- a/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/models/ResponseWrapper.java
+++ b/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/models/ResponseWrapper.java
@@ -1,40 +1,36 @@
 package com.xxAMIDOxx.xxSTACKSxx.api.models;
 
-        import com.fasterxml.jackson.annotation.JsonCreator;
-        import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-        import com.fasterxml.jackson.annotation.JsonProperty;
-
-        import java.util.List;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ResponseWrapper {
 
-    private final Integer pageSize;
-    private final Integer pageNumber;
-    private final List<Menu> results;
+  private final Integer pageSize;
+  private final Integer pageNumber;
+  private final List<Menu> results;
 
+  @JsonCreator
+  public ResponseWrapper(
+      @JsonProperty("pageSize") Integer pageSize,
+      @JsonProperty("pageNumber") Integer pageNumber,
+      @JsonProperty("results") List<Menu> results) {
+    this.pageSize = pageSize;
+    this.pageNumber = pageNumber;
+    this.results = results;
+  }
 
-    @JsonCreator
-    public ResponseWrapper(
-            @JsonProperty("pageSize") Integer pageSize,
+  public Integer getPageSize() {
+    return pageSize;
+  }
 
-            @JsonProperty("pageNumber") Integer pageNumber,
+  public Integer getPageNumber() {
+    return pageNumber;
+  }
 
-            @JsonProperty("results") List<Menu> results) {
-        this.pageSize = pageSize;
-        this.pageNumber = pageNumber;
-        this.results = results;
-    }
-
-    public Integer getPageSize() {
-        return pageSize;
-    }
-
-    public Integer getPageNumber() {
-        return pageNumber;
-    }
-
-    public List<Menu> getResults() {
-        return results;
-    }
+  public List<Menu> getResults() {
+    return results;
+  }
 }

--- a/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/pact/GenericMenuConsumer.java
+++ b/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/pact/GenericMenuConsumer.java
@@ -1,140 +1,141 @@
 package com.xxAMIDOxx.xxSTACKSxx.api.pact;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import au.com.dius.pact.consumer.Pact;
 import au.com.dius.pact.consumer.PactProviderRuleMk2;
 import au.com.dius.pact.consumer.PactVerification;
 import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
 import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
 import au.com.dius.pact.model.RequestResponsePact;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.Rule;
 import org.junit.Test;
 import org.springframework.http.*;
 import org.springframework.web.client.RestTemplate;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class GenericMenuConsumer {
 
-    @Rule
-    public PactProviderRuleMk2 mockProvider = new PactProviderRuleMk2("JavaMenuAPI", "localhost", 8080, this);
+  @Rule
+  public PactProviderRuleMk2 mockProvider =
+      new PactProviderRuleMk2("JavaMenuAPI", "localhost", 8080, this);
 
-    private final RestTemplate restTemplate = new RestTemplate();
+  private final RestTemplate restTemplate = new RestTemplate();
 
-    private PactDslJsonBody expectedSearchByTermResults() {
-        PactDslJsonBody response = new PactDslJsonBody();
-        response.integerType("pageSize", 20)
-                .integerType("pageNumber", 1)
-                .array("menu");
-        return response;
-    }
+  private PactDslJsonBody expectedSearchByTermResults() {
+    PactDslJsonBody response = new PactDslJsonBody();
+    response.integerType("pageSize", 20).integerType("pageNumber", 1).array("menu");
+    return response;
+  }
 
-    private PactDslJsonBody expectedMenu() {
-        PactDslJsonBody response = new PactDslJsonBody();
-        response.uuid("id")
-                .uuid("tenantId")
-                .stringType("name", "Dessert Menu (Automated Test Data)")
-                .stringType("description")
-                .booleanType("enabled");
-        return response;
-    }
+  private PactDslJsonBody expectedMenu() {
+    PactDslJsonBody response = new PactDslJsonBody();
+    response
+        .uuid("id")
+        .uuid("tenantId")
+        .stringType("name", "Dessert Menu (Automated Test Data)")
+        .stringType("description")
+        .booleanType("enabled");
+    return response;
+  }
 
-    private PactDslJsonBody expectedCreateMenuResponse() {
-        PactDslJsonBody response = new PactDslJsonBody();
-        response.uuid("id");
-        return response;
-    }
+  private PactDslJsonBody expectedCreateMenuResponse() {
+    PactDslJsonBody response = new PactDslJsonBody();
+    response.uuid("id");
+    return response;
+  }
 
-    private PactDslJsonBody genericCategory() {
-        PactDslJsonBody response = new PactDslJsonBody();
-        response.uuid("id")
-                .stringType("name", "Cheese Cakes (Automated Test Data)")
-                .stringType("description", "category description")
-                .array("items");
-        return response;
-    }
+  private PactDslJsonBody genericCategory() {
+    PactDslJsonBody response = new PactDslJsonBody();
+    response
+        .uuid("id")
+        .stringType("name", "Cheese Cakes (Automated Test Data)")
+        .stringType("description", "category description")
+        .array("items");
+    return response;
+  }
 
-    private PactDslJsonBody genericItem() {
-        PactDslJsonBody response = new PactDslJsonBody();
-        response.uuid("id")
-                .stringType("name", "Coconut Cheese Cake (Automated Test Data)")
-                .stringType("description", "item description")
-                .booleanType("available");
-        return response;
-    }
+  private PactDslJsonBody genericItem() {
+    PactDslJsonBody response = new PactDslJsonBody();
+    response
+        .uuid("id")
+        .stringType("name", "Coconut Cheese Cake (Automated Test Data)")
+        .stringType("description", "item description")
+        .booleanType("available");
+    return response;
+  }
 
+  @Pact(consumer = "JavaAutomatedTestsMenuConsumer")
+  public RequestResponsePact createPact(PactDslWithProvider builder) {
+    Map<String, String> headers = new HashMap<>();
+    headers.put("Content-Type", "application/json");
 
-    @Pact(consumer = "JavaAutomatedTestsMenuConsumer")
-    public RequestResponsePact createPact(PactDslWithProvider builder) {
-        Map<String, String> headers = new HashMap<>();
-        headers.put("Content-Type", "application/json");
+    return builder
+        .given("Get all menus")
+        .uponReceiving("GET REQUEST")
+        .path("/v1/menu")
+        .method("GET")
+        .willRespondWith()
+        .status(200)
+        .headers(headers)
+        .body("{\"pageSize\":20,\"pageNumber\":1}")
+        .given("Create a new menu")
+        .uponReceiving("POST REQUEST")
+        .method("POST")
+        .headers(headers)
+        .body(expectedMenu())
+        .path("/v1/menu")
+        .willRespondWith()
+        .body(expectedCreateMenuResponse())
+        .status(201)
+        .given("Search menu by 'search term'")
+        .uponReceiving("GET REQUEST BY TERM")
+        .method("GET")
+        .headers(headers)
+        .path("/v1/menu")
+        .query("searchTerm=Dessert Menu (Automated Test Data)")
+        .willRespondWith()
+        .status(200)
+        .body(expectedSearchByTermResults())
+        .toPact();
+  }
 
-        return builder
-                .given("Get all menus")
-                .uponReceiving("GET REQUEST")
-                .path("/v1/menu")
-                .method("GET")
-                .willRespondWith()
-                .status(200)
-                .headers(headers)
-                .body("{\"pageSize\":20,\"pageNumber\":1}")
+  @Test
+  @PactVerification()
+  public void givenGet_whenSendRequest_shouldReturn200WithProperHeaderAndBody() {
+    // get all
+    ResponseEntity<String> response =
+        new RestTemplate().getForEntity(mockProvider.getUrl() + "/v1/menu", String.class);
 
-                .given("Create a new menu")
-                .uponReceiving("POST REQUEST")
-                .method("POST")
-                .headers(headers)
-                .body(expectedMenu())
-                .path("/v1/menu")
-                .willRespondWith()
-                .body(expectedCreateMenuResponse())
-                .status(201)
+    assertThat(response.getStatusCode().value()).isEqualTo(200);
+    assertThat(response.getHeaders().get("Content-Type").contains("application/json")).isTrue();
+    assertThat(response.getBody()).contains("pageSize", "20", "pageNumber", "1");
 
-                .given("Search menu by 'search term'")
-                .uponReceiving("GET REQUEST BY TERM")
-                .method("GET")
-                .headers(headers)
-                .path("/v1/menu")
-                .query("searchTerm=Dessert Menu (Automated Test Data)")
-                .willRespondWith()
-                .status(200)
-                .body(expectedSearchByTermResults())
+    // post
+    HttpHeaders httpHeaders = new HttpHeaders();
+    httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+    String jsonBody = expectedMenu().toString();
 
-                .toPact();
-    }
+    ResponseEntity<String> postResponse =
+        restTemplate.exchange(
+            mockProvider.getUrl() + "/v1/menu",
+            HttpMethod.POST,
+            new HttpEntity<>(jsonBody, httpHeaders),
+            String.class);
 
+    assertThat(postResponse.getStatusCode().value()).isEqualTo(201);
 
-    @Test
-    @PactVerification()
-    public void givenGet_whenSendRequest_shouldReturn200WithProperHeaderAndBody() {
-        // get all
-        ResponseEntity<String> response = new RestTemplate().getForEntity(mockProvider.getUrl() + "/v1/menu", String.class);
+    // searchTerm
+    ResponseEntity<String> getByTermResponse =
+        restTemplate.exchange(
+            mockProvider.getUrl() + "/v1/menu?searchTerm=Dessert Menu (Automated Test Data)",
+            HttpMethod.GET,
+            new HttpEntity<>(httpHeaders),
+            String.class);
 
-        assertThat(response.getStatusCode().value()).isEqualTo(200);
-        assertThat(response.getHeaders().get("Content-Type").contains("application/json")).isTrue();
-        assertThat(response.getBody()).contains("pageSize", "20", "pageNumber", "1");
-
-        // post
-        HttpHeaders httpHeaders = new HttpHeaders();
-        httpHeaders.setContentType(MediaType.APPLICATION_JSON);
-        String jsonBody = expectedMenu().toString();
-
-        ResponseEntity<String> postResponse = restTemplate
-                .exchange(mockProvider.getUrl() + "/v1/menu", HttpMethod.POST, new HttpEntity<>(jsonBody, httpHeaders), String.class);
-
-        assertThat(postResponse.getStatusCode().value()).isEqualTo(201);
-
-
-
-        // searchTerm
-        ResponseEntity<String> getByTermResponse = restTemplate
-                .exchange(mockProvider.getUrl() + "/v1/menu?searchTerm=Dessert Menu (Automated Test Data)",
-                        HttpMethod.GET, new HttpEntity<>(httpHeaders), String.class);
-
-        assertThat(getByTermResponse.getStatusCode().value()).isEqualTo(200);
-        assertThat(getByTermResponse.getBody()).contains("pageSize", "pageNumber");
-        assertThat(getByTermResponse.getBody().contains("Dessert Menu (Automated Test Data)"));
-
-    }
+    assertThat(getByTermResponse.getStatusCode().value()).isEqualTo(200);
+    assertThat(getByTermResponse.getBody()).contains("pageSize", "pageNumber");
+    assertThat(getByTermResponse.getBody().contains("Dessert Menu (Automated Test Data)"));
+  }
 }

--- a/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/status/AppStatus.java
+++ b/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/status/AppStatus.java
@@ -1,5 +1,6 @@
 package com.xxAMIDOxx.xxSTACKSxx.api.status;
 
 public enum AppStatus {
-    RUNNING, DOWN
+  RUNNING,
+  DOWN
 }

--- a/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/status/ApplicationStatus.java
+++ b/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/status/ApplicationStatus.java
@@ -5,20 +5,19 @@ import io.restassured.RestAssured;
 import net.serenitybdd.rest.SerenityRest;
 import net.thucydides.core.annotations.Step;
 
-
 public class ApplicationStatus {
 
-   final String BASE_URL = WebServiceEndPoints.BASE_URL.getUrl();
+  final String BASE_URL = WebServiceEndPoints.BASE_URL.getUrl();
 
-    public AppStatus currentStatus() {
-        String path = BASE_URL + WebServiceEndPoints.STATUS.getUrl();
-        int statusCode = RestAssured.get(path).statusCode();
+  public AppStatus currentStatus() {
+    String path = BASE_URL + WebServiceEndPoints.STATUS.getUrl();
+    int statusCode = RestAssured.get(path).statusCode();
 
-        return (statusCode == 200) ? AppStatus.RUNNING : AppStatus.DOWN;
-    }
+    return (statusCode == 200) ? AppStatus.RUNNING : AppStatus.DOWN;
+  }
 
-    @Step("Get current status message")
-    public void readStatusMessage() {
-        SerenityRest.get(BASE_URL + WebServiceEndPoints.STATUS.getUrl());
-    }
+  @Step("Get current status message")
+  public void readStatusMessage() {
+    SerenityRest.get(BASE_URL + WebServiceEndPoints.STATUS.getUrl());
+  }
 }

--- a/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/stepdefinitions/ApplicationStatusStepDefinitions.java
+++ b/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/stepdefinitions/ApplicationStatusStepDefinitions.java
@@ -1,5 +1,9 @@
 package com.xxAMIDOxx.xxSTACKSxx.api.stepdefinitions;
 
+import static net.serenitybdd.rest.SerenityRest.restAssuredThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
 import com.xxAMIDOxx.xxSTACKSxx.api.status.AppStatus;
 import com.xxAMIDOxx.xxSTACKSxx.api.status.ApplicationStatus;
 import io.cucumber.java.en.Given;
@@ -8,32 +12,28 @@ import io.cucumber.java.en.When;
 import net.thucydides.core.annotations.Steps;
 import org.hamcrest.Matchers;
 
-import static net.serenitybdd.rest.SerenityRest.restAssuredThat;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-
 public class ApplicationStatusStepDefinitions {
 
-    @Steps
-    ApplicationStatus theApplication;
+  @Steps ApplicationStatus theApplication;
 
-    @Given("the application is running")
-    public void the_application_is_running() {
-        assertThat(theApplication.currentStatus()).isEqualTo(AppStatus.RUNNING);
-    }
+  @Given("the application is running")
+  public void the_application_is_running() {
+    assertThat(theApplication.currentStatus()).isEqualTo(AppStatus.RUNNING);
+  }
 
-    @When("I check the application status")
-    public void check_the_application_status() {
-        theApplication.readStatusMessage();
-    }
+  @When("I check the application status")
+  public void check_the_application_status() {
+    theApplication.readStatusMessage();
+  }
 
-    @Then("the API should return {string}")
-    public void the_API_should_return(String expectedMessage) {
-        restAssuredThat(lastResponse -> lastResponse.body(equalTo(expectedMessage)));
-    }
+  @Then("the API should return {string}")
+  public void the_API_should_return(String expectedMessage) {
+    restAssuredThat(lastResponse -> lastResponse.body(equalTo(expectedMessage)));
+  }
 
-    @Then("the API should return {string} status")
-    public void the_API_return_status(String status) {
-        restAssuredThat (lastResponse -> lastResponse.body("status", Matchers.equalToIgnoringCase(status)));
-    }
+  @Then("the API should return {string} status")
+  public void the_API_return_status(String status) {
+    restAssuredThat(
+        lastResponse -> lastResponse.body("status", Matchers.equalToIgnoringCase(status)));
+  }
 }

--- a/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/stepdefinitions/CategoryStepDefinitions.java
+++ b/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/stepdefinitions/CategoryStepDefinitions.java
@@ -1,5 +1,8 @@
 package com.xxAMIDOxx.xxSTACKSxx.api.stepdefinitions;
 
+import static net.serenitybdd.rest.SerenityRest.lastResponse;
+import static net.serenitybdd.rest.SerenityRest.restAssuredThat;
+
 import com.xxAMIDOxx.xxSTACKSxx.api.ExceptionMessages;
 import com.xxAMIDOxx.xxSTACKSxx.api.WebServiceEndPoints;
 import com.xxAMIDOxx.xxSTACKSxx.api.category.CategoryActions;
@@ -12,130 +15,130 @@ import com.xxAMIDOxx.xxSTACKSxx.api.templates.FieldValues;
 import com.xxAMIDOxx.xxSTACKSxx.api.templates.MergeFrom;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 import net.serenitybdd.core.Serenity;
 import net.serenitybdd.rest.SerenityRest;
 import net.thucydides.core.annotations.Steps;
 import org.junit.Assert;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-
-import static net.serenitybdd.rest.SerenityRest.lastResponse;
-import static net.serenitybdd.rest.SerenityRest.restAssuredThat;
-
 public class CategoryStepDefinitions {
 
-    @Steps
-    private CategoryRequests categoryRequests;
+  @Steps private CategoryRequests categoryRequests;
 
-    @Steps
-    private MenuRequests menuRequests;
+  @Steps private MenuRequests menuRequests;
 
-    @Steps
-    private MenuActions menuActions;
+  @Steps private MenuActions menuActions;
 
-    private final String MENU_URL = WebServiceEndPoints.BASE_URL.getUrl() + WebServiceEndPoints.MENU.getUrl();
+  private final String MENU_URL =
+      WebServiceEndPoints.BASE_URL.getUrl() + WebServiceEndPoints.MENU.getUrl();
 
-    private String categoryBody;
-    private String menuId;
-    private String categoryId;
+  private String categoryBody;
+  private String menuId;
+  private String categoryId;
 
-    @When("the following category data:")
-    public void create_the_category_body(List<Map<String, String>> categoryDetails) throws IOException {
-        categoryBody = MergeFrom.template("templates/category.json")
-                .withDefaultValuesFrom(FieldValues.in("templates/standard-category.properties"))
-                .withFieldsFrom(categoryDetails.get(0));
+  @When("the following category data:")
+  public void create_the_category_body(List<Map<String, String>> categoryDetails)
+      throws IOException {
+    categoryBody =
+        MergeFrom.template("templates/category.json")
+            .withDefaultValuesFrom(FieldValues.in("templates/standard-category.properties"))
+            .withFieldsFrom(categoryDetails.get(0));
 
-        Serenity.setSessionVariable("CategoryBody").to(categoryBody);
-    }
+    Serenity.setSessionVariable("CategoryBody").to(categoryBody);
+  }
 
-    @When("I create a new category for the existing menu")
-    public void i_create_the_category_for_existing_menu() {
-        menuId = Serenity.getCurrentSession().get("MenuId").toString();
-        categoryRequests.createCategory(categoryBody, menuId);
-    }
+  @When("I create a new category for the existing menu")
+  public void i_create_the_category_for_existing_menu() {
+    menuId = Serenity.getCurrentSession().get("MenuId").toString();
+    categoryRequests.createCategory(categoryBody, menuId);
+  }
 
-    @Then("the category was successfully created")
-    public void the_category_was_successfully_created() {
-        restAssuredThat(response -> response.statusCode(201));
-        categoryId = menuActions.getIdOfLastCreatedObject();
-        Serenity.setSessionVariable("CategoryId").to(categoryId);
-    }
+  @Then("the category was successfully created")
+  public void the_category_was_successfully_created() {
+    restAssuredThat(response -> response.statusCode(201));
+    categoryId = menuActions.getIdOfLastCreatedObject();
+    Serenity.setSessionVariable("CategoryId").to(categoryId);
+  }
 
-    @Then("I update the category with the following data:")
-    public void i_update_the_category_with_following_data(List<Map<String, String>> menuDetails) throws IOException {
-        menuId = Serenity.getCurrentSession().get("MenuId").toString();
-        categoryId = Serenity.getCurrentSession().get("CategoryId").toString();
-        create_the_category_body(menuDetails);
+  @Then("I update the category with the following data:")
+  public void i_update_the_category_with_following_data(List<Map<String, String>> menuDetails)
+      throws IOException {
+    menuId = Serenity.getCurrentSession().get("MenuId").toString();
+    categoryId = Serenity.getCurrentSession().get("CategoryId").toString();
+    create_the_category_body(menuDetails);
 
-        categoryRequests.updateCategory(categoryBody, menuId, categoryId);
-    }
+    categoryRequests.updateCategory(categoryBody, menuId, categoryId);
+  }
 
-    @Then("I update the category for the menu with {string} id with the following data:")
-    public void update_the_category_for_menu(String menu_id, List<Map<String, String>> menuDetails) throws IOException {
-        create_the_category_body(menuDetails);
+  @Then("I update the category for the menu with {string} id with the following data:")
+  public void update_the_category_for_menu(String menu_id, List<Map<String, String>> menuDetails)
+      throws IOException {
+    create_the_category_body(menuDetails);
 
-        categoryRequests.updateCategory(categoryBody, menu_id,
-                Serenity.getCurrentSession().get("CategoryId").toString());
-    }
+    categoryRequests.updateCategory(
+        categoryBody, menu_id, Serenity.getCurrentSession().get("CategoryId").toString());
+  }
 
-    @Then("I update the category with {string} id with the following data:")
-    public void update_the_category_for_given_id(String category_id, List<Map<String, String>> menuDetails) throws IOException {
-        create_the_category_body(menuDetails);
-        categoryRequests.updateCategory(categoryBody, menuId, category_id);
-    }
+  @Then("I update the category with {string} id with the following data:")
+  public void update_the_category_for_given_id(
+      String category_id, List<Map<String, String>> menuDetails) throws IOException {
+    create_the_category_body(menuDetails);
+    categoryRequests.updateCategory(categoryBody, menuId, category_id);
+  }
 
-    @Then("the menu should include the following category data:")
-    public void the_menu_contains_the_following_category_data(List<Map<String, String>> menuDetails) {
-        the_category_should_include_the_following_data(menuDetails);
-    }
+  @Then("the menu should include the following category data:")
+  public void the_menu_contains_the_following_category_data(List<Map<String, String>> menuDetails) {
+    the_category_should_include_the_following_data(menuDetails);
+  }
 
-    @When("I create a new category for the menu with {string} id")
-    public void i_create_a_new_category_for_the_menu_with_id(String menu_id) {
-        categoryRequests.createCategory(categoryBody, menu_id);
-    }
+  @When("I create a new category for the menu with {string} id")
+  public void i_create_a_new_category_for_the_menu_with_id(String menu_id) {
+    categoryRequests.createCategory(categoryBody, menu_id);
+  }
 
-    @When("I delete the created category")
-    public void i_delete_the_last_created_category() {
-        categoryRequests.deleteTheCategory(menuId, categoryId);
-    }
+  @When("I delete the created category")
+  public void i_delete_the_last_created_category() {
+    categoryRequests.deleteTheCategory(menuId, categoryId);
+  }
 
-    @When("I delete the category with {string} id")
-    public void i_delete_category_by_id(String id) {
-        String menu_id = String.valueOf(Serenity.getCurrentSession().get("MenuId"));
-        categoryRequests.deleteTheCategory(menu_id, id);
-    }
+  @When("I delete the category with {string} id")
+  public void i_delete_category_by_id(String id) {
+    String menu_id = String.valueOf(Serenity.getCurrentSession().get("MenuId"));
+    categoryRequests.deleteTheCategory(menu_id, id);
+  }
 
-    @When("I delete the category with {string} id for {string} menu")
-    public void i_delete_category_by_id(String category_id, String menu_id) {
-        categoryRequests.deleteTheCategory(menu_id, category_id);
-    }
+  @When("I delete the category with {string} id for {string} menu")
+  public void i_delete_category_by_id(String category_id, String menu_id) {
+    categoryRequests.deleteTheCategory(menu_id, category_id);
+  }
 
-    @When("the category is successfully deleted")
-    public void the_category_was_successfully_deleted() {
-        menuRequests.getMenu(menuId);
-        Menu actualMenu = menuActions.responseToMenu(lastResponse());
+  @When("the category is successfully deleted")
+  public void the_category_was_successfully_deleted() {
+    menuRequests.getMenu(menuId);
+    Menu actualMenu = menuActions.responseToMenu(lastResponse());
 
-        Assert.assertEquals(0, actualMenu.getCategories().size());
-    }
+    Assert.assertEquals(0, actualMenu.getCategories().size());
+  }
 
-    @Then("the 'category does not exist' message is returned")
-    public void i_check_the_category_does_not_exist_message() {
-        menuActions.check_exception_message(ExceptionMessages.CATEGORY_DOES_NOT_EXIST, lastResponse());
-    }
+  @Then("the 'category does not exist' message is returned")
+  public void i_check_the_category_does_not_exist_message() {
+    menuActions.check_exception_message(ExceptionMessages.CATEGORY_DOES_NOT_EXIST, lastResponse());
+  }
 
-    @Then("the 'category already exists' message is returned")
-    public void i_check_the_category_already_exists_message() {
-        menuActions.check_exception_message(ExceptionMessages.CATEGORY_ALREADY_EXISTS, lastResponse());
-    }
+  @Then("the 'category already exists' message is returned")
+  public void i_check_the_category_already_exists_message() {
+    menuActions.check_exception_message(ExceptionMessages.CATEGORY_ALREADY_EXISTS, lastResponse());
+  }
 
-    @Then("the created category should include the following data:")
-    public void the_category_should_include_the_following_data(List<Map<String, String>> categoryDetails) {
-        SerenityRest.get(MENU_URL.concat("/".concat(menuId)));
-        Category expectedCategory = CategoryActions.mapToCategory(categoryDetails.get(0), categoryId);
+  @Then("the created category should include the following data:")
+  public void the_category_should_include_the_following_data(
+      List<Map<String, String>> categoryDetails) {
+    SerenityRest.get(MENU_URL.concat("/".concat(menuId)));
+    Category expectedCategory = CategoryActions.mapToCategory(categoryDetails.get(0), categoryId);
 
-        Menu actualMenu = menuActions.responseToMenu(lastResponse());
-        Assert.assertTrue(actualMenu != null && actualMenu.getCategories().contains(expectedCategory));
-    }
+    Menu actualMenu = menuActions.responseToMenu(lastResponse());
+    Assert.assertTrue(actualMenu != null && actualMenu.getCategories().contains(expectedCategory));
+  }
 }

--- a/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/stepdefinitions/Hooks.java
+++ b/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/stepdefinitions/Hooks.java
@@ -1,51 +1,48 @@
 package com.xxAMIDOxx.xxSTACKSxx.api.stepdefinitions;
 
+import static net.serenitybdd.rest.SerenityRest.lastResponse;
+import static net.serenitybdd.rest.SerenityRest.restAssuredThat;
+
 import com.xxAMIDOxx.xxSTACKSxx.api.menu.MenuRequests;
 import com.xxAMIDOxx.xxSTACKSxx.api.models.Menu;
 import com.xxAMIDOxx.xxSTACKSxx.api.models.ResponseWrapper;
 import io.cucumber.java.After;
 import io.cucumber.java.Before;
+import java.util.List;
 import net.serenitybdd.core.Serenity;
 import net.serenitybdd.cucumber.suiteslicing.SerenityTags;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
-
-import static net.serenitybdd.rest.SerenityRest.lastResponse;
-import static net.serenitybdd.rest.SerenityRest.restAssuredThat;
-
 public class Hooks {
 
-    private final static Logger LOGGER = LoggerFactory.getLogger(Hooks.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(Hooks.class);
 
+  public static void deleteAllMenusFromPreviousRun() {
+    MenuRequests.getMenusBySearchTerm("(Automated Test Data)");
+    ResponseWrapper responseWrapper = lastResponse().body().as(ResponseWrapper.class);
+    List<Menu> listOfMenusToDelete = responseWrapper.getResults();
 
-    public static void deleteAllMenusFromPreviousRun() {
-        MenuRequests.getMenusBySearchTerm("(Automated Test Data)");
-        ResponseWrapper responseWrapper = lastResponse().body().as(ResponseWrapper.class);
-        List<Menu> listOfMenusToDelete = responseWrapper.getResults();
+    for (Menu currentMenu : listOfMenusToDelete) {
+      MenuRequests.deleteTheMenu(currentMenu.getId());
+      restAssuredThat(response -> response.statusCode(200));
 
-        for (Menu currentMenu : listOfMenusToDelete) {
-            MenuRequests.deleteTheMenu(currentMenu.getId());
-            restAssuredThat(response -> response.statusCode(200));
-
-            LOGGER.info(String.format("The menu with '%s' id was successfully deleted.", currentMenu.getId()));
-        }
+      LOGGER.info(
+          String.format("The menu with '%s' id was successfully deleted.", currentMenu.getId()));
     }
+  }
 
+  @Before
+  public void before() {
+    SerenityTags.create().tagScenarioWithBatchingInfo();
+  }
 
-    @Before
-    public void before() {
-        SerenityTags.create().tagScenarioWithBatchingInfo();
+  @After("@DeleteCreatedMenu")
+  public void afterFirst() {
+    String menuId = String.valueOf(Serenity.getCurrentSession().get("MenuId"));
+    if (!menuId.isEmpty()) {
+      MenuRequests.deleteTheMenu(menuId);
+      LOGGER.info(String.format("The menu with '%s' id was successfully deleted.", menuId));
     }
-
-
-    @After("@DeleteCreatedMenu")
-    public void afterFirst() {
-        String menuId = String.valueOf(Serenity.getCurrentSession().get("MenuId"));
-        if (!menuId.isEmpty()) {
-            MenuRequests.deleteTheMenu(menuId);
-            LOGGER.info(String.format("The menu with '%s' id was successfully deleted.", menuId));
-        }
-    }
+  }
 }

--- a/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/stepdefinitions/ItemStepDefinitions.java
+++ b/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/stepdefinitions/ItemStepDefinitions.java
@@ -1,5 +1,8 @@
 package com.xxAMIDOxx.xxSTACKSxx.api.stepdefinitions;
 
+import static net.serenitybdd.rest.SerenityRest.lastResponse;
+import static net.serenitybdd.rest.SerenityRest.restAssuredThat;
+
 import com.xxAMIDOxx.xxSTACKSxx.api.ExceptionMessages;
 import com.xxAMIDOxx.xxSTACKSxx.api.item.ItemActions;
 import com.xxAMIDOxx.xxSTACKSxx.api.item.ItemRequests;
@@ -13,165 +16,159 @@ import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
-import net.serenitybdd.core.Serenity;
-import net.thucydides.core.annotations.Steps;
-import org.junit.Assert;
-
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
-import static net.serenitybdd.rest.SerenityRest.lastResponse;
-import static net.serenitybdd.rest.SerenityRest.restAssuredThat;
+import net.serenitybdd.core.Serenity;
+import net.thucydides.core.annotations.Steps;
+import org.junit.Assert;
 
 public class ItemStepDefinitions {
 
-    @Steps
-    ItemRequests itemRequest;
+  @Steps ItemRequests itemRequest;
 
-    @Steps
-    MenuRequests menuRequest;
+  @Steps MenuRequests menuRequest;
 
-    @Steps
-    MenuActions menuActions;
+  @Steps MenuActions menuActions;
 
-    String menuId;
-    String categoryId;
-    String itemBody;
-    String itemId;
+  String menuId;
+  String categoryId;
+  String itemBody;
+  String itemId;
 
-    @Given("the following item data:")
-    public void the_following_item_data(List<Map<String, String>> itemDetails) throws IOException {
-        itemBody = MergeFrom.template("templates/item.json")
-                .withDefaultValuesFrom(FieldValues.in("templates/standard-item.properties"))
-                .withFieldsFrom(itemDetails.get(0));
+  @Given("the following item data:")
+  public void the_following_item_data(List<Map<String, String>> itemDetails) throws IOException {
+    itemBody =
+        MergeFrom.template("templates/item.json")
+            .withDefaultValuesFrom(FieldValues.in("templates/standard-item.properties"))
+            .withFieldsFrom(itemDetails.get(0));
 
-        Serenity.setSessionVariable("Item").to(itemBody);
-    }
+    Serenity.setSessionVariable("Item").to(itemBody);
+  }
 
-    @When("I create an item for the following menu and category:")
-    public void create_item_for_menu_and_category(DataTable table) {
-        List<List<String>> data = table.asLists(String.class);
-        String menu_id = data.get(0).get(1);
-        String category_id = data.get(1).get(1);
+  @When("I create an item for the following menu and category:")
+  public void create_item_for_menu_and_category(DataTable table) {
+    List<List<String>> data = table.asLists(String.class);
+    String menu_id = data.get(0).get(1);
+    String category_id = data.get(1).get(1);
 
-        itemRequest.createItem(itemBody, menu_id, category_id);
-    }
+    itemRequest.createItem(itemBody, menu_id, category_id);
+  }
 
-    @When("I create an item for the following {string} menu and {string} category")
-    public void create_item_for_menu_and_category(String menu_id, String category_id) {
-        itemRequest.createItem(itemBody, menu_id, category_id);
-    }
+  @When("I create an item for the following {string} menu and {string} category")
+  public void create_item_for_menu_and_category(String menu_id, String category_id) {
+    itemRequest.createItem(itemBody, menu_id, category_id);
+  }
 
-    @When("I create an item for the menu with {string} id")
-    public void create_item_for_given_menu(String menu_id) {
-        create_item_for_menu_and_category(menu_id,
-                Serenity.getCurrentSession().get("CategoryId").toString());
-    }
+  @When("I create an item for the menu with {string} id")
+  public void create_item_for_given_menu(String menu_id) {
+    create_item_for_menu_and_category(
+        menu_id, Serenity.getCurrentSession().get("CategoryId").toString());
+  }
 
-    @When("I create an item for the category with {string} id")
-    public void create_item_for_given_category(String category_id) {
-        create_item_for_menu_and_category(Serenity.getCurrentSession().get("MenuId").toString(),
-                category_id);
-    }
+  @When("I create an item for the category with {string} id")
+  public void create_item_for_given_category(String category_id) {
+    create_item_for_menu_and_category(
+        Serenity.getCurrentSession().get("MenuId").toString(), category_id);
+  }
 
-    @When("I create an item for the previous menu and category")
-    public void create_item_for_menu_and_category() {
-        menuId = Serenity.getCurrentSession().get("MenuId").toString();
-        categoryId = Serenity.getCurrentSession().get("CategoryId").toString();
-        itemRequest.createItem(itemBody, menuId, categoryId);
-    }
+  @When("I create an item for the previous menu and category")
+  public void create_item_for_menu_and_category() {
+    menuId = Serenity.getCurrentSession().get("MenuId").toString();
+    categoryId = Serenity.getCurrentSession().get("CategoryId").toString();
+    itemRequest.createItem(itemBody, menuId, categoryId);
+  }
 
-    @When("I delete the created item")
-    public void i_delete_the_last_created_item() {
-        itemRequest.deleteTheItem(menuId, categoryId, itemId);
-    }
+  @When("I delete the created item")
+  public void i_delete_the_last_created_item() {
+    itemRequest.deleteTheItem(menuId, categoryId, itemId);
+  }
 
-    @When("I delete the item for the menu with {string} id")
-    public void i_delete_the_item_for_given_menuId(String menu_id) {
-        itemRequest.deleteTheItem(menu_id, categoryId, itemId);
-    }
+  @When("I delete the item for the menu with {string} id")
+  public void i_delete_the_item_for_given_menuId(String menu_id) {
+    itemRequest.deleteTheItem(menu_id, categoryId, itemId);
+  }
 
-    @When("I delete the item for the category with {string} id")
-    public void i_delete_the_item_for_given_categoryId(String category_id) {
-        itemRequest.deleteTheItem(menuId, category_id, itemId);
-    }
+  @When("I delete the item for the category with {string} id")
+  public void i_delete_the_item_for_given_categoryId(String category_id) {
+    itemRequest.deleteTheItem(menuId, category_id, itemId);
+  }
 
-    @When("the item is successfully deleted")
-    public void the_category_was_successfully_deleted() {
-        menuRequest.getMenu(menuId);
-        Menu actualMenu = menuActions.responseToMenu(lastResponse());
+  @When("the item is successfully deleted")
+  public void the_category_was_successfully_deleted() {
+    menuRequest.getMenu(menuId);
+    Menu actualMenu = menuActions.responseToMenu(lastResponse());
 
-        Assert.assertEquals(0, actualMenu.getCategories().get(0).getItems().size());
-    }
+    Assert.assertEquals(0, actualMenu.getCategories().get(0).getItems().size());
+  }
 
+  @Then("the item was successfully created")
+  public void the_item_was_successfully_created() {
+    restAssuredThat(response -> response.statusCode(201));
+    itemId = menuActions.getIdOfLastCreatedObject();
+  }
 
-    @Then("the item was successfully created")
-    public void the_item_was_successfully_created() {
-        restAssuredThat(response -> response.statusCode(201));
-        itemId = menuActions.getIdOfLastCreatedObject();
-    }
+  @Then("the created item should include the following data:")
+  public void the_created_item_contain_correct_data(List<Map<String, String>> itemDetails) {
+    menuRequest.getMenu(menuId);
 
+    Item expectedItem = ItemActions.mapToItem(itemDetails.get(0), itemId);
+    Menu actualMenu = menuActions.responseToMenu(lastResponse());
 
-    @Then("the created item should include the following data:")
-    public void the_created_item_contain_correct_data(List<Map<String, String>> itemDetails) {
-        menuRequest.getMenu(menuId);
+    List<Item> actualItems =
+        actualMenu.getCategories().stream()
+            .filter(cat -> cat.getId().equals(categoryId))
+            .flatMap(category -> category.getItems().stream())
+            .collect(Collectors.toList());
 
-        Item expectedItem = ItemActions.mapToItem(itemDetails.get(0), itemId);
-        Menu actualMenu = menuActions.responseToMenu(lastResponse());
+    Assert.assertTrue(actualItems.contains(expectedItem));
+  }
 
-        List<Item> actualItems = actualMenu.getCategories()
-                .stream()
-                .filter(cat -> cat.getId().equals(categoryId))
-                .flatMap(category -> category.getItems().stream())
-                .collect(Collectors.toList());
+  @Then("the item should include the following data:")
+  public void the_updated_item_contain_correct_data(List<Map<String, String>> itemDetails) {
+    the_created_item_contain_correct_data(itemDetails);
+  }
 
-        Assert.assertTrue(actualItems.contains(expectedItem));
-    }
+  @Then("the 'item already exists' message is returned")
+  public void i_check_the_menu_already_exist_message() {
+    menuActions.check_exception_message(ExceptionMessages.ITEM_ALREADY_EXISTS, lastResponse());
+  }
 
+  @Then("the 'item does not exist' message is returned")
+  public void i_check_the_menu_does_not_exist_message() {
+    menuActions.check_exception_message(ExceptionMessages.ITEM_DOES_NOT_EXIST, lastResponse());
+  }
 
-    @Then("the item should include the following data:")
-    public void the_updated_item_contain_correct_data(List<Map<String, String>> itemDetails) {
-        the_created_item_contain_correct_data(itemDetails);
-    }
+  @When("I delete the item with {string} id")
+  public void i_delete_item_by_id(String item_id) {
+    String menu_id = String.valueOf(Serenity.getCurrentSession().get("MenuId"));
+    String category_id = String.valueOf(Serenity.getCurrentSession().get("CategoryId"));
 
-    @Then("the 'item already exists' message is returned")
-    public void i_check_the_menu_already_exist_message() {
-        menuActions.check_exception_message(ExceptionMessages.ITEM_ALREADY_EXISTS, lastResponse());
-    }
+    itemRequest.deleteTheItem(menu_id, category_id, item_id);
+  }
 
-    @Then("the 'item does not exist' message is returned")
-    public void i_check_the_menu_does_not_exist_message() {
-        menuActions.check_exception_message(ExceptionMessages.ITEM_DOES_NOT_EXIST, lastResponse());
-    }
+  @Then("I update the item with the following data:")
+  public void i_update_the_menu_with_following_data(List<Map<String, String>> itemDetails)
+      throws IOException {
+    menuId = Serenity.getCurrentSession().get("MenuId").toString();
+    categoryId = Serenity.getCurrentSession().get("CategoryId").toString();
+    the_following_item_data(itemDetails);
 
-    @When("I delete the item with {string} id")
-    public void i_delete_item_by_id(String item_id) {
-        String menu_id = String.valueOf(Serenity.getCurrentSession().get("MenuId"));
-        String category_id = String.valueOf(Serenity.getCurrentSession().get("CategoryId"));
+    itemRequest.updateItem(itemBody, menuId, categoryId, itemId);
+  }
 
-        itemRequest.deleteTheItem(menu_id, category_id, item_id);
-    }
+  @Then("I update the item with the following data for the menu with {string} id:")
+  public void i_update_the_menu_for_given_menu(
+      String menu_id, List<Map<String, String>> itemDetails) throws IOException {
+    the_following_item_data(itemDetails);
+    itemRequest.updateItem(itemBody, menu_id, categoryId, itemId);
+  }
 
-    @Then("I update the item with the following data:")
-    public void i_update_the_menu_with_following_data(List<Map<String, String>> itemDetails) throws IOException {
-        menuId = Serenity.getCurrentSession().get("MenuId").toString();
-        categoryId = Serenity.getCurrentSession().get("CategoryId").toString();
-        the_following_item_data(itemDetails);
-
-        itemRequest.updateItem(itemBody, menuId, categoryId, itemId);
-    }
-
-    @Then("I update the item with the following data for the menu with {string} id:")
-    public void i_update_the_menu_for_given_menu(String menu_id, List<Map<String, String>> itemDetails) throws IOException {
-        the_following_item_data(itemDetails);
-        itemRequest.updateItem(itemBody, menu_id, categoryId, itemId);
-    }
-
-    @Then("I update the item with the following data for the category with {string} id:")
-    public void i_update_the_menu_for_given_category(String category_id, List<Map<String, String>> itemDetails) throws IOException {
-        the_following_item_data(itemDetails);
-        itemRequest.updateItem(itemBody, menuId, category_id, itemId);
-    }
+  @Then("I update the item with the following data for the category with {string} id:")
+  public void i_update_the_menu_for_given_category(
+      String category_id, List<Map<String, String>> itemDetails) throws IOException {
+    the_following_item_data(itemDetails);
+    itemRequest.updateItem(itemBody, menuId, category_id, itemId);
+  }
 }

--- a/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/stepdefinitions/MenuStepDefinitions.java
+++ b/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/stepdefinitions/MenuStepDefinitions.java
@@ -1,5 +1,9 @@
 package com.xxAMIDOxx.xxSTACKSxx.api.stepdefinitions;
 
+import static net.serenitybdd.rest.SerenityRest.lastResponse;
+import static net.serenitybdd.rest.SerenityRest.restAssuredThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.xxAMIDOxx.xxSTACKSxx.api.ExceptionMessages;
 import com.xxAMIDOxx.xxSTACKSxx.api.WebServiceEndPoints;
 import com.xxAMIDOxx.xxSTACKSxx.api.menu.MenuActions;
@@ -13,6 +17,9 @@ import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 import net.serenitybdd.core.Serenity;
 import net.serenitybdd.rest.SerenityRest;
 import net.thucydides.core.annotations.Steps;
@@ -22,240 +29,226 @@ import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-
-import static net.serenitybdd.rest.SerenityRest.lastResponse;
-import static net.serenitybdd.rest.SerenityRest.restAssuredThat;
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class MenuStepDefinitions {
 
-    private final static Logger LOGGER = LoggerFactory.getLogger(MenuStepDefinitions.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(MenuStepDefinitions.class);
 
-    @Steps
-    MenuRequests menuRequest;
+  @Steps MenuRequests menuRequest;
 
-    @Steps
-    TemplateResponse theMenuDetails;
+  @Steps TemplateResponse theMenuDetails;
 
-    @Steps
-    MenuActions menuActions;
+  @Steps MenuActions menuActions;
 
-    String menuId;
-    String menuBody;
-    final String BASE_URL = WebServiceEndPoints.BASE_URL.getUrl();
+  String menuId;
+  String menuBody;
+  final String BASE_URL = WebServiceEndPoints.BASE_URL.getUrl();
 
+  @Given("the following menu data:")
+  public void create_menu_body_from_data(List<Map<String, String>> menuDetails) throws IOException {
+    menuBody =
+        MergeFrom.template("templates/menu.json")
+            .withDefaultValuesFrom(FieldValues.in("templates/standard-menu.properties"))
+            .withFieldsFrom(menuDetails.get(0));
 
-    @Given("the following menu data:")
-    public void create_menu_body_from_data(List<Map<String, String>> menuDetails) throws IOException {
-        menuBody = MergeFrom.template("templates/menu.json")
-                .withDefaultValuesFrom(FieldValues.in("templates/standard-menu.properties"))
-                .withFieldsFrom(menuDetails.get(0));
+    Serenity.setSessionVariable("Menu").to(menuBody);
+  }
 
-        Serenity.setSessionVariable("Menu").to(menuBody);
+  @Given("the menu list is not empty")
+  public void get_all_existing_menus() {
+    menuRequest.getAllMenus();
+    restAssuredThat(response -> response.statusCode(200));
+    restAssuredThat(lastResponse -> lastResponse.body("results", Matchers.notNullValue()));
+  }
+
+  @When("I create the menu")
+  public void i_create_the_menu() {
+    menuRequest.createMenu(menuBody);
+  }
+
+  @When("I search the created menu by id")
+  public void i_search_the_last_created_menu_by_id() {
+    getMenuByParameter(menuId);
+  }
+
+  public void getMenuByParameter(String parameter) {
+    SerenityRest.get(
+        BASE_URL.concat(WebServiceEndPoints.MENU.getUrl()).concat("/").concat(parameter));
+  }
+
+  @When("I search the menu by:")
+  public void search_the_menu_by_parameter(DataTable table) {
+    List<List<String>> data = table.asLists(String.class);
+    String parameter = data.get(1).get(0);
+    String value = data.get(0).get(0);
+
+    getMenuByParameter(parameter);
+    Serenity.setSessionVariable(value).to(parameter);
+  }
+
+  @When("I search the menu by criteria")
+  public void search_the_menu_by_multiple_parameters(DataTable table) {
+    List<List<String>> data = table.asLists(String.class);
+    String xPath = MenuActions.createUrlWithCriteria(data);
+    String parametrisedPath = BASE_URL + WebServiceEndPoints.MENU.getUrl() + "?" + xPath;
+
+    SerenityRest.get(parametrisedPath);
+  }
+
+  @When("I get the restaurant id for last created menu")
+  public void getLastCreatedRestaurantId() {
+    Serenity.setSessionVariable("RestaurantId").to(menuActions.getRestaurantIdOfLastCreatedMenu());
+  }
+
+  @When("I search the menu by restaurant id")
+  public void getMenuById() {
+    String restaurant_id = String.valueOf(Serenity.getCurrentSession().get("RestaurantId"));
+    String parametrisedPath =
+        BASE_URL.concat(WebServiceEndPoints.MENU.getUrl()).concat("?restaurantId=") + restaurant_id;
+
+    SerenityRest.get(parametrisedPath);
+  }
+
+  @Then("the {int} items are returned")
+  public void the_items_are_returned(Integer expectedSize) {
+    String response = SerenityRest.lastResponse().prettyPrint();
+
+    JSONObject js = MenuActions.toJson(response);
+    Assert.assertEquals(js.getJSONArray("results").length(), (int) expectedSize);
+  }
+
+  @Then("the menu should include the following details:")
+  public void the_menu_contains_the_following_details(List<Map<String, String>> menuDetails) {
+    Map<String, String> expectedResponse = menuDetails.get(0);
+    String actualResponse = theMenuDetails.returned().getOrDefault("results", null);
+
+    assertThat(actualResponse).contains(expectedResponse.values());
+  }
+
+  @Then("the menu should include the following data:")
+  public void the_menu_contains_the_following_data(List<Map<String, String>> menuDetails) {
+    restAssuredThat(response -> response.statusCode(200));
+
+    String id = menuActions.getIdOfLastCreatedObject();
+    Menu expectedMenu = MenuActions.mapToMenu(menuDetails.get(0), id);
+
+    Menu actualMenu = lastResponse().getBody().as(Menu.class);
+    assertThat(expectedMenu).isEqualToIgnoringGivenFields(actualMenu, "categories");
+  }
+
+  @When("I search the updated menu")
+  public void i_search_the_updated_menu() {
+    i_search_the_last_created_menu_by_id();
+  }
+
+  @Then("the menu was successfully created")
+  public void the_menu_was_created() {
+    restAssuredThat(response -> response.statusCode(201));
+    menuId = menuActions.getIdOfLastCreatedObject();
+    Serenity.setSessionVariable("MenuId").to(menuId);
+  }
+
+  @Then("the returned status code is {int}")
+  public void i_check_the_status_code(int statusCode) {
+    restAssuredThat(response -> response.statusCode(statusCode));
+  }
+
+  @Then("the error {string} is {string}")
+  public void i_check_the_error_message(String errorField, String errorMessage) {
+    restAssuredThat(status -> status.body(errorField, Matchers.equalToIgnoringCase(errorMessage)));
+  }
+
+  @Then("the 'menu does not exist' message is returned")
+  public void i_check_the_menu_does_not_exist_message() {
+    menuActions.check_exception_message(ExceptionMessages.MENU_DOES_NOT_EXIST, lastResponse());
+  }
+
+  @Then("the 'menu already exists' message is returned")
+  public void i_check_the_menu_already_exist_message() {
+    menuActions.check_exception_message(ExceptionMessages.MENU_ALREADY_EXISTS, lastResponse());
+  }
+
+  @Then("I update the menu with the following data:")
+  public void i_update_the_menu_with_following_data(List<Map<String, String>> menuDetails)
+      throws IOException {
+    String id = menuActions.getIdOfLastCreatedObject();
+    create_menu_body_from_data(menuDetails);
+
+    menuRequest.updateMenu(menuBody, id);
+  }
+
+  @When("I update the menu for {string} id with data:")
+  public void i_update_the_menu_with_data(String id, List<Map<String, String>> menuDetails)
+      throws IOException {
+    create_menu_body_from_data(menuDetails);
+    menuRequest.updateMenu(menuBody, id);
+  }
+
+  @When("I delete the menu")
+  public void i_delete_the_menu() {
+    menuId = menuActions.getIdOfLastCreatedObject();
+    MenuRequests.deleteTheMenu(menuId);
+    LOGGER.info(String.format("The menu with '%s' id was successfully deleted.", menuId));
+  }
+
+  @When("I delete the menu with {string} id")
+  public void i_delete_the_menu_by_id(String menuId) {
+    MenuRequests.deleteTheMenu(menuId);
+  }
+
+  @Then("the menu is successfully deleted")
+  public void the_menu_is_successfully_deleted() {
+    restAssuredThat(response -> response.statusCode(200));
+    menuRequest.getMenu(menuId);
+
+    restAssuredThat(response -> response.statusCode(404));
+    menuActions.check_exception_message(ExceptionMessages.MENU_DOES_NOT_EXIST, lastResponse());
+  }
+
+  @Given("the menu list is empty")
+  public void the_menu_list_is_empty() {
+    menuRequest.getAllMenus();
+    ResponseWrapper responseWrapper = lastResponse().body().as(ResponseWrapper.class);
+
+    restAssuredThat(response -> response.statusCode(200));
+    Assert.assertEquals(0, responseWrapper.getResults().size());
+  }
+
+  @Given("I delete all existing menus")
+  public void i_delete_all_existing_menus() {
+    ResponseWrapper responseWrapper = lastResponse().body().as(ResponseWrapper.class);
+    List<Menu> allMenus = responseWrapper.getResults();
+
+    for (Menu currentMenu : allMenus) {
+      MenuRequests.deleteTheMenu(currentMenu.getId());
+      restAssuredThat(response -> response.statusCode(200));
+
+      LOGGER.info(
+          String.format("The menu with '%s' id was successfully deleted.", currentMenu.getId()));
     }
+  }
 
-    @Given("the menu list is not empty")
-    public void get_all_existing_menus() {
-        menuRequest.getAllMenus();
-        restAssuredThat(response -> response.statusCode(200));
-        restAssuredThat(lastResponse -> lastResponse.body("results", Matchers.notNullValue()));
-    }
+  @Given("I delete all menus from previous tests")
+  public void i_delete_all_existing_menus_from_test_data() {
+    Hooks.deleteAllMenusFromPreviousRun();
+  }
 
-    @When("I create the menu")
-    public void i_create_the_menu() {
-        menuRequest.createMenu(menuBody);
-    }
+  @When("I search the created menu by id in the v2 app version")
+  public void i_search_the_last_created_menu_by_id_v2() {
+    getMenuByParameter_v2(menuId);
+  }
 
-    @When("I search the created menu by id")
-    public void i_search_the_last_created_menu_by_id() {
-        getMenuByParameter(menuId);
-    }
+  public void getMenuByParameter_v2(String parameter) {
+    SerenityRest.get(
+        BASE_URL.concat(WebServiceEndPoints.MENU_V2.getUrl()).concat("/").concat(parameter));
+  }
 
-    public void getMenuByParameter(String parameter) {
-        SerenityRest.get(BASE_URL.concat(WebServiceEndPoints.MENU.getUrl()).concat("/").concat(parameter));
-    }
+  @When("in the v2 app version I search the menu by:")
+  public void search_the_menu_by_parameter_v2(DataTable table) {
+    List<List<String>> data = table.asLists(String.class);
+    String parameter = data.get(1).get(0);
+    String value = data.get(0).get(0);
 
-    @When("I search the menu by:")
-    public void search_the_menu_by_parameter(DataTable table) {
-        List<List<String>> data = table.asLists(String.class);
-        String parameter = data.get(1).get(0);
-        String value = data.get(0).get(0);
-
-        getMenuByParameter(parameter);
-        Serenity.setSessionVariable(value).to(parameter);
-    }
-
-    @When("I search the menu by criteria")
-    public void search_the_menu_by_multiple_parameters(DataTable table) {
-        List<List<String>> data = table.asLists(String.class);
-        String xPath = MenuActions.createUrlWithCriteria(data);
-        String parametrisedPath = BASE_URL + WebServiceEndPoints.MENU.getUrl() + "?" + xPath;
-
-        SerenityRest.get(parametrisedPath);
-    }
-
-    @When("I get the restaurant id for last created menu")
-    public void getLastCreatedRestaurantId() {
-        Serenity.setSessionVariable("RestaurantId").to(menuActions.getRestaurantIdOfLastCreatedMenu());
-    }
-
-    @When("I search the menu by restaurant id")
-    public void getMenuById() {
-        String restaurant_id = String.valueOf(Serenity.getCurrentSession().get("RestaurantId"));
-        String parametrisedPath = BASE_URL.concat(WebServiceEndPoints.MENU.getUrl()).concat("?restaurantId=") + restaurant_id;
-
-        SerenityRest.get(parametrisedPath);
-    }
-
-
-    @Then("the {int} items are returned")
-    public void the_items_are_returned(Integer expectedSize) {
-        String response = SerenityRest.lastResponse().prettyPrint();
-
-        JSONObject js = MenuActions.toJson(response);
-        Assert.assertEquals(js.getJSONArray("results").length(), (int) expectedSize);
-    }
-
-
-    @Then("the menu should include the following details:")
-    public void the_menu_contains_the_following_details(List<Map<String, String>> menuDetails) {
-        Map<String, String> expectedResponse = menuDetails.get(0);
-        String actualResponse = theMenuDetails.returned().getOrDefault("results", null);
-
-        assertThat(actualResponse).contains(expectedResponse.values());
-    }
-
-    @Then("the menu should include the following data:")
-    public void the_menu_contains_the_following_data(List<Map<String, String>> menuDetails) {
-        restAssuredThat(response -> response.statusCode(200));
-
-        String id = menuActions.getIdOfLastCreatedObject();
-        Menu expectedMenu = MenuActions.mapToMenu(menuDetails.get(0), id);
-
-        Menu actualMenu = lastResponse().getBody().as(Menu.class);
-        assertThat(expectedMenu).isEqualToIgnoringGivenFields(actualMenu, "categories");
-    }
-
-
-    @When("I search the updated menu")
-    public void i_search_the_updated_menu() {
-        i_search_the_last_created_menu_by_id();
-    }
-
-
-    @Then("the menu was successfully created")
-    public void the_menu_was_created() {
-        restAssuredThat(response -> response.statusCode(201));
-        menuId = menuActions.getIdOfLastCreatedObject();
-        Serenity.setSessionVariable("MenuId").to(menuId);
-    }
-
-
-    @Then("the returned status code is {int}")
-    public void i_check_the_status_code(int statusCode) {
-        restAssuredThat(response -> response.statusCode(statusCode));
-    }
-
-
-    @Then("the error {string} is {string}")
-    public void i_check_the_error_message(String errorField, String errorMessage) {
-        restAssuredThat(status -> status.body(errorField, Matchers.equalToIgnoringCase(errorMessage)));
-    }
-
-
-    @Then("the 'menu does not exist' message is returned")
-    public void i_check_the_menu_does_not_exist_message() {
-        menuActions.check_exception_message(ExceptionMessages.MENU_DOES_NOT_EXIST, lastResponse());
-    }
-
-    @Then("the 'menu already exists' message is returned")
-    public void i_check_the_menu_already_exist_message() {
-        menuActions.check_exception_message(ExceptionMessages.MENU_ALREADY_EXISTS, lastResponse());
-    }
-
-    @Then("I update the menu with the following data:")
-    public void i_update_the_menu_with_following_data(List<Map<String, String>> menuDetails) throws IOException {
-        String id = menuActions.getIdOfLastCreatedObject();
-        create_menu_body_from_data(menuDetails);
-
-        menuRequest.updateMenu(menuBody, id);
-    }
-
-
-    @When("I update the menu for {string} id with data:")
-    public void i_update_the_menu_with_data(String id, List<Map<String, String>> menuDetails) throws IOException {
-        create_menu_body_from_data(menuDetails);
-        menuRequest.updateMenu(menuBody, id);
-    }
-
-    @When("I delete the menu")
-    public void i_delete_the_menu() {
-        menuId = menuActions.getIdOfLastCreatedObject();
-        MenuRequests.deleteTheMenu(menuId);
-        LOGGER.info(String.format("The menu with '%s' id was successfully deleted.", menuId));
-    }
-
-    @When("I delete the menu with {string} id")
-    public void i_delete_the_menu_by_id(String menuId) {
-        MenuRequests.deleteTheMenu(menuId);
-    }
-
-    @Then("the menu is successfully deleted")
-    public void the_menu_is_successfully_deleted() {
-        restAssuredThat(response -> response.statusCode(200));
-        menuRequest.getMenu(menuId);
-
-        restAssuredThat(response -> response.statusCode(404));
-        menuActions.check_exception_message(ExceptionMessages.MENU_DOES_NOT_EXIST, lastResponse());
-    }
-
-    @Given("the menu list is empty")
-    public void the_menu_list_is_empty() {
-        menuRequest.getAllMenus();
-        ResponseWrapper responseWrapper = lastResponse().body().as(ResponseWrapper.class);
-
-        restAssuredThat(response -> response.statusCode(200));
-        Assert.assertEquals(0, responseWrapper.getResults().size());
-    }
-
-
-    @Given("I delete all existing menus")
-    public void i_delete_all_existing_menus() {
-        ResponseWrapper responseWrapper = lastResponse().body().as(ResponseWrapper.class);
-        List<Menu> allMenus = responseWrapper.getResults();
-
-        for (Menu currentMenu : allMenus) {
-            MenuRequests.deleteTheMenu(currentMenu.getId());
-            restAssuredThat(response -> response.statusCode(200));
-
-            LOGGER.info(String.format("The menu with '%s' id was successfully deleted.", currentMenu.getId()));
-        }
-    }
-
-    @Given("I delete all menus from previous tests")
-    public void i_delete_all_existing_menus_from_test_data() {
-        Hooks.deleteAllMenusFromPreviousRun();
-    }
-
-    @When("I search the created menu by id in the v2 app version")
-    public void i_search_the_last_created_menu_by_id_v2() {
-        getMenuByParameter_v2(menuId);
-    }
-
-    public void getMenuByParameter_v2(String parameter) {
-        SerenityRest.get(BASE_URL.concat(WebServiceEndPoints.MENU_V2.getUrl()).concat("/").concat(parameter));
-    }
-
-    @When("in the v2 app version I search the menu by:")
-    public void search_the_menu_by_parameter_v2(DataTable table) {
-        List<List<String>> data = table.asLists(String.class);
-        String parameter = data.get(1).get(0);
-        String value = data.get(0).get(0);
-
-        getMenuByParameter_v2(parameter);
-        Serenity.setSessionVariable(value).to(parameter);
-    }
+    getMenuByParameter_v2(parameter);
+    Serenity.setSessionVariable(value).to(parameter);
+  }
 }

--- a/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/templates/FieldValues.java
+++ b/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/templates/FieldValues.java
@@ -1,18 +1,16 @@
 package com.xxAMIDOxx.xxSTACKSxx.api.templates;
 
+import static java.util.stream.Collectors.toMap;
+
 import java.io.IOException;
 import java.util.Map;
 import java.util.Properties;
 
-import static java.util.stream.Collectors.toMap;
-
 public class FieldValues {
-    public static Map<String, String> in(String propertiesFile) throws IOException {
-        Properties properties = new Properties();
-        properties.load(FieldValues.class.getResourceAsStream("/" + propertiesFile));
-        return properties.entrySet()
-                .stream()
-                .collect(toMap(entry -> entry.getKey().toString(),
-                               entry -> entry.getValue().toString()));
-    }
+  public static Map<String, String> in(String propertiesFile) throws IOException {
+    Properties properties = new Properties();
+    properties.load(FieldValues.class.getResourceAsStream("/" + propertiesFile));
+    return properties.entrySet().stream()
+        .collect(toMap(entry -> entry.getKey().toString(), entry -> entry.getValue().toString()));
+  }
 }

--- a/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/templates/FreemarkerTemplate.java
+++ b/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/templates/FreemarkerTemplate.java
@@ -6,25 +6,24 @@ import freemarker.template.TemplateExceptionHandler;
 
 public class FreemarkerTemplate {
 
-    private Configuration configuration = null;
+  private Configuration configuration = null;
 
-    private Configuration getConfiguration() {
-        if (configuration == null) {
-            configuration = new Configuration(Configuration.VERSION_2_3_28);
-            configuration.setDefaultEncoding("UTF-8");
-            configuration.setClassForTemplateLoading(FreemarkerTemplate.class, "/");
-            configuration.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);
-        }
-
-        return configuration;
+  private Configuration getConfiguration() {
+    if (configuration == null) {
+      configuration = new Configuration(Configuration.VERSION_2_3_28);
+      configuration.setDefaultEncoding("UTF-8");
+      configuration.setClassForTemplateLoading(FreemarkerTemplate.class, "/");
+      configuration.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);
     }
 
+    return configuration;
+  }
 
-    public Template getTemplate(String templateFile) {
-        try {
-            return getConfiguration().getTemplate(templateFile);
-        } catch (Exception e) {
-            throw new IllegalStateException("Could not find template " + templateFile, e);
-        }
+  public Template getTemplate(String templateFile) {
+    try {
+      return getConfiguration().getTemplate(templateFile);
+    } catch (Exception e) {
+      throw new IllegalStateException("Could not find template " + templateFile, e);
     }
+  }
 }

--- a/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/templates/MergeFrom.java
+++ b/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/templates/MergeFrom.java
@@ -2,47 +2,45 @@ package com.xxAMIDOxx.xxSTACKSxx.api.templates;
 
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
-
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.util.HashMap;
 import java.util.Map;
 
-
 public class MergeFrom {
-    private String templateFile;
-    private Map<String, String> defaultValues;
+  private String templateFile;
+  private Map<String, String> defaultValues;
 
-    private static FreemarkerTemplate freemarkerTemplate = new FreemarkerTemplate();
+  private static FreemarkerTemplate freemarkerTemplate = new FreemarkerTemplate();
 
-    public MergeFrom(String templateFile) {
-        this.templateFile = templateFile;
+  public MergeFrom(String templateFile) {
+    this.templateFile = templateFile;
+  }
+
+  public static MergeFrom template(String template) {
+    return new MergeFrom(template);
+  }
+
+  public MergeFrom withDefaultValuesFrom(Map<String, String> defaultValues) {
+    this.defaultValues = defaultValues;
+    return this;
+  }
+
+  public String withFieldsFrom(Map<String, String> fieldValues) {
+    Map<String, String> fieldDictionary = new HashMap<>(defaultValues);
+    fieldDictionary.putAll(fieldValues);
+
+    Template template = freemarkerTemplate.getTemplate(templateFile);
+
+    Writer writer = new StringWriter();
+
+    try {
+      template.process(fieldDictionary, writer);
+    } catch (TemplateException | IOException e) {
+      throw new IllegalStateException("Failed to merge test data template", e);
     }
 
-    public static MergeFrom template(String template) {
-        return new MergeFrom(template);
-    }
-
-    public MergeFrom withDefaultValuesFrom(Map<String, String> defaultValues) {
-        this.defaultValues = defaultValues;
-        return this;
-    }
-
-    public String withFieldsFrom(Map<String, String> fieldValues) {
-        Map<String, String> fieldDictionary = new HashMap<>(defaultValues);
-        fieldDictionary.putAll(fieldValues);
-
-        Template template = freemarkerTemplate.getTemplate(templateFile);
-
-        Writer writer = new StringWriter();
-
-        try {
-            template.process(fieldDictionary, writer);
-        } catch (TemplateException | IOException e) {
-            throw new IllegalStateException("Failed to merge test data template", e);
-        }
-
-        return writer.toString();
-    }
+    return writer.toString();
+  }
 }

--- a/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/templates/TemplateResponse.java
+++ b/api-tests/src/test/java/com/xxAMIDOxx/xxSTACKSxx/api/templates/TemplateResponse.java
@@ -1,20 +1,17 @@
 package com.xxAMIDOxx.xxSTACKSxx.api.templates;
 
-import net.serenitybdd.rest.SerenityRest;
-
-import java.util.Map;
-
 import static java.util.stream.Collectors.toMap;
 
-public class TemplateResponse {
-    public Map<String, String> returned() {
-       return mapOfStringsFrom(SerenityRest.lastResponse().getBody().as(Map.class));
-    }
+import java.util.Map;
+import net.serenitybdd.rest.SerenityRest;
 
-    private Map<String,String> mapOfStringsFrom(Map<String, Object> map) {
-        return map.entrySet()
-                .stream()
-                .collect(toMap(Map.Entry::getKey,
-                        entry -> entry.getValue().toString()));
-    }
+public class TemplateResponse {
+  public Map<String, String> returned() {
+    return mapOfStringsFrom(SerenityRest.lastResponse().getBody().as(Map.class));
+  }
+
+  private Map<String, String> mapOfStringsFrom(Map<String, Object> map) {
+    return map.entrySet().stream()
+        .collect(toMap(Map.Entry::getKey, entry -> entry.getValue().toString()));
+  }
 }

--- a/build/azDevops/azure/azure-pipelines-javaspring-k8s.yml
+++ b/build/azDevops/azure/azure-pipelines-javaspring-k8s.yml
@@ -25,7 +25,7 @@ resources:
     - repository: templates
       type: github
       name: amido/stacks-pipeline-templates
-      ref: refs/tags/v1.4.6
+      ref: refs/tags/v1.4.8
       # EXCHANGE THIS FOR YOUR OWN ENDPOINT CONNECTION TO GITHUB
       # REPOSITORY IS PUBLIC
       endpoint: amidostacks

--- a/build/azDevops/azure/templates/steps/build/build-api-tests.yml
+++ b/build/azDevops/azure/templates/steps/build/build-api-tests.yml
@@ -37,6 +37,36 @@ steps:
       container: ${{ parameters.docker_build_container }}
     displayName: "Maven: Install Packages (${{ parameters.project_type }})"
 
+  - task: Bash@3
+    inputs:
+      filePath: "${{ parameters.pipeline_scripts_directory }}/test-maven-checkstyle-check.bash"
+      arguments: >
+        -Z "${{ parameters.maven_cache_directory }}"
+      workingDirectory: "${{ parameters.project_root_dir }}"
+    target:
+      container: ${{ parameters.docker_build_container }}
+    displayName: "Maven: Checkstyle Check (${{ parameters.project_type }})"
+
+  - task: Bash@3
+    inputs:
+      filePath: "${{ parameters.pipeline_scripts_directory }}/test-maven-format-check.bash"
+      arguments: >
+        -Z "${{ parameters.maven_cache_directory }}"
+      workingDirectory: "${{ parameters.project_root_dir }}"
+    target:
+      container: ${{ parameters.docker_build_container }}
+    displayName: "Maven: Format Check (${{ parameters.project_type }})"
+
+  - task: Bash@3
+    inputs:
+      filePath: "${{ parameters.pipeline_scripts_directory }}/test-maven-checkstyle-check.bash"
+      arguments: >
+        -Z "${{ parameters.maven_cache_directory }}"
+      workingDirectory: "${{ parameters.project_root_dir }}"
+    target:
+      container: ${{ parameters.docker_build_container }}
+    displayName: "Maven: Spotbugs Check (${{ parameters.project_type }})"
+
   - ${{ if eq(parameters.vulnerability_scan, true) }}:
       - task: Bash@3
         inputs:

--- a/build/azDevops/azure/templates/steps/build/build-api-tests.yml
+++ b/build/azDevops/azure/templates/steps/build/build-api-tests.yml
@@ -42,7 +42,7 @@ steps:
       filePath: "${{ parameters.pipeline_scripts_directory }}/test-maven-checkstyle-check.bash"
       arguments: >
         -Z "${{ parameters.maven_cache_directory }}"
-      workingDirectory: "${{ parameters.project_root_dir }}"
+      workingDirectory: "${{ parameters.functional_test_project_root_dir }}"
     target:
       container: ${{ parameters.docker_build_container }}
     displayName: "Maven: Checkstyle Check (${{ parameters.project_type }})"
@@ -52,7 +52,7 @@ steps:
       filePath: "${{ parameters.pipeline_scripts_directory }}/test-maven-format-check.bash"
       arguments: >
         -Z "${{ parameters.maven_cache_directory }}"
-      workingDirectory: "${{ parameters.project_root_dir }}"
+      workingDirectory: "${{ parameters.functional_test_project_root_dir }}"
     target:
       container: ${{ parameters.docker_build_container }}
     displayName: "Maven: Format Check (${{ parameters.project_type }})"
@@ -62,7 +62,7 @@ steps:
       filePath: "${{ parameters.pipeline_scripts_directory }}/test-maven-checkstyle-check.bash"
       arguments: >
         -Z "${{ parameters.maven_cache_directory }}"
-      workingDirectory: "${{ parameters.project_root_dir }}"
+      workingDirectory: "${{ parameters.functional_test_project_root_dir }}"
     target:
       container: ${{ parameters.docker_build_container }}
     displayName: "Maven: Spotbugs Check (${{ parameters.project_type }})"

--- a/build/azDevops/azure/templates/steps/build/build-java.yml
+++ b/build/azDevops/azure/templates/steps/build/build-java.yml
@@ -33,6 +33,36 @@ steps:
       container: ${{ parameters.docker_build_container }}
     displayName: "Maven: Install Packages (${{ parameters.project_type }})"
 
+  - task: Bash@3
+    inputs:
+      filePath: "${{ parameters.pipeline_scripts_directory }}/test-maven-checkstyle-check.bash"
+      arguments: >
+        -Z "${{ parameters.maven_cache_directory }}"
+      workingDirectory: "${{ parameters.project_root_dir }}"
+    target:
+      container: ${{ parameters.docker_build_container }}
+    displayName: "Maven: Checkstyle Check (${{ parameters.project_type }})"
+
+  - task: Bash@3
+    inputs:
+      filePath: "${{ parameters.pipeline_scripts_directory }}/test-maven-format-check.bash"
+      arguments: >
+        -Z "${{ parameters.maven_cache_directory }}"
+      workingDirectory: "${{ parameters.project_root_dir }}"
+    target:
+      container: ${{ parameters.docker_build_container }}
+    displayName: "Maven: Format Check (${{ parameters.project_type }})"
+
+  - task: Bash@3
+    inputs:
+      filePath: "${{ parameters.pipeline_scripts_directory }}/test-maven-checkstyle-check.bash"
+      arguments: >
+        -Z "${{ parameters.maven_cache_directory }}"
+      workingDirectory: "${{ parameters.project_root_dir }}"
+    target:
+      container: ${{ parameters.docker_build_container }}
+    displayName: "Maven: Spotbugs Check (${{ parameters.project_type }})"
+
   - ${{ if eq(parameters.vulnerability_scan, true) }}:
       - task: Bash@3
         inputs:

--- a/build/jenkins/azure/jenkins-pipelines-javaspring-k8s.Jenkinsfile
+++ b/build/jenkins/azure/jenkins-pipelines-javaspring-k8s.Jenkinsfile
@@ -153,7 +153,7 @@ pipeline {
             dir("${self_pipeline_repo}") {
               checkout([
                 $class: 'GitSCM',
-                branches: [[name: 'refs/tags/v1.4.6']],
+                branches: [[name: 'refs/tags/v1.4.8']],
                 userRemoteConfigs: [[url: "https://github.com/amido/${self_pipeline_repo}"]]
               ])
             }
@@ -228,6 +228,30 @@ pipeline {
                         -Z "${maven_cache_directory}"
                     """,
                     label: "Maven: Install Packages (${java_project_type})"
+                  )
+
+                  sh(
+                    script: """#!/bin/bash
+                      bash "${dynamic_build_scripts_directory}/test-maven-checkstyle-check.bash" \
+                        -Z "${maven_cache_directory}"
+                    """,
+                    label: "Maven: Checkstyle Check (${java_project_type})"
+                  )
+
+                  sh(
+                    script: """#!/bin/bash
+                      bash "${dynamic_build_scripts_directory}/test-maven-format-check.bash" \
+                        -Z "${maven_cache_directory}"
+                    """,
+                    label: "Maven: Format Check (${java_project_type})"
+                  )
+
+                  sh(
+                    script: """#!/bin/bash
+                      bash "${dynamic_build_scripts_directory}/test-maven-spotbugs-check.bash" \
+                        -Z "${maven_cache_directory}"
+                    """,
+                    label: "Maven: Spotbugs Check (${java_project_type})"
                   )
 
                   sh(
@@ -353,6 +377,30 @@ pipeline {
                         -Z "${maven_cache_directory}"
                     """,
                     label: "Maven: Install Packages (${functional_test_project_type})"
+                  )
+
+                  sh(
+                    script: """#!/bin/bash
+                      bash "${dynamic_build_scripts_directory}/test-maven-checkstyle-check.bash" \
+                        -Z "${maven_cache_directory}"
+                    """,
+                    label: "Maven: Checkstyle Check (${functional_test_project_type})"
+                  )
+
+                  sh(
+                    script: """#!/bin/bash
+                      bash "${dynamic_build_scripts_directory}/test-maven-format-check.bash" \
+                        -Z "${maven_cache_directory}"
+                    """,
+                    label: "Maven: Format Check (${functional_test_project_type})"
+                  )
+
+                  sh(
+                    script: """#!/bin/bash
+                      bash "${dynamic_build_scripts_directory}/test-maven-spotbugs-check.bash" \
+                        -Z "${maven_cache_directory}"
+                    """,
+                    label: "Maven: Spotbugs Check (${functional_test_project_type})"
                   )
 
                   sh(

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -353,13 +353,6 @@
                     <skipSortingImports>false</skipSortingImports>
                     <style>google</style>
                 </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>format</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -384,9 +377,6 @@
                     <execution>
                         <id>validate</id>
                         <phase>validate</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/java/src/main/java/com/xxAMIDOxx/xxSTACKSxx/core/operations/OperationContext.java
+++ b/java/src/main/java/com/xxAMIDOxx/xxSTACKSxx/core/operations/OperationContext.java
@@ -10,6 +10,9 @@ public abstract class OperationContext {
     this.correlationId = correlationId;
   }
 
+  /** No arg constructor. */
+  public OperationContext() {}
+
   public int getOperationCode() {
     return operationCode;
   }


### PR DESCRIPTION
2355 - Enable CheckStyle and fmt to be run as separate plugin  

#### 📲 What

Removed the goal from fmt and CheckStyle in pom
Adds checktyle, format, and spotbugs into both Pipelines
Formats api test code properly

#### 🤔 Why
To allow these to be only run specifically

#### 🛠 How

Can call the plugin directly when these needs to be run.

#### 👀 Evidence

Screenshots / external resources / links / etc.
Link to documentation updated with changes impacted in the PR

#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
