### PR TITLE
Removing cosmos db url and upgrade libraries

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.4.0</version>
+        <version>2.3.5.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.4.RELEASE</version>
+        <version>2.4.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -19,13 +19,13 @@
     <properties>
         <java.version>11</java.version>
         <org.projectlombok.version>1.18.0</org.projectlombok.version>
-        <org.springdoc-openapi.version>1.4.8</org.springdoc-openapi.version>
+        <org.springdoc-openapi.version>1.5.0</org.springdoc-openapi.version>
         <applicationinsights.version>2.6.2</applicationinsights.version>
         <cosmosdb.version>2.3.5</cosmosdb.version>
         <azure.springboot.version>2.3.5</azure.springboot.version>
-        <azure.servicebus.version>3.4.0</azure.servicebus.version>
+        <azure.servicebus.version>3.5.1</azure.servicebus.version>
         <jackson.version>2.11.0</jackson.version>
-        <mockito.version>3.5.15</mockito.version>
+        <mockito.version>3.6.0</mockito.version>
         <lombok.version>1.18.16</lombok.version>
         <hamcrest.version>2.2</hamcrest.version>
         <pitest.version>1.5.2</pitest.version>
@@ -35,12 +35,12 @@
         <junit-jupiter.version>5.7.0</junit-jupiter.version>
         <equals-verifier.version>3.5</equals-verifier.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-        <owasp-dependency-check-plugin.version>6.0.2</owasp-dependency-check-plugin.version>
+        <owasp-dependency-check-plugin.version>6.0.3</owasp-dependency-check-plugin.version>
         <auth0-spring-security-api.version>1.4.0</auth0-spring-security-api.version>
 
         <fmt-maven-plugin.version>2.10</fmt-maven-plugin.version>
         <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
-        <puppycrawl-tools-checkstyle.version>8.36.2</puppycrawl-tools-checkstyle.version>
+        <puppycrawl-tools-checkstyle.version>8.37</puppycrawl-tools-checkstyle.version>
         <spotbugs-maven-plugin.version>4.1.4</spotbugs-maven-plugin.version>
         <spotbugs.version>4.1.4</spotbugs.version>
         <pact.version>3.5.24</pact.version>
@@ -205,7 +205,7 @@
         <dependency>
             <groupId>au.com.dius.pact</groupId>
             <artifactId>consumer</artifactId>
-            <version>4.1.9</version>
+            <version>4.1.11</version>
             <scope>test</scope>
         </dependency>
 
@@ -347,7 +347,7 @@
             <plugin>
                 <groupId>au.com.dius.pact.provider</groupId>
                 <artifactId>maven</artifactId>
-                <version>4.1.9</version>
+                <version>4.1.11</version>
                 <configuration>
                     <pactBrokerUrl>${pact.broker.url}</pactBrokerUrl>
                     <pactBrokerToken>${pact.broker.token}</pactBrokerToken>
@@ -448,7 +448,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                  <threads>15</threads>
+                    <threads>15</threads>
                     <historyInputFile>target/pitHistory.txt</historyInputFile>
                     <historyOutputFile>target/pitHistory.txt</historyOutputFile>
                     <timestampedReports>false</timestampedReports>

--- a/java/src/main/resources/application.yml
+++ b/java/src/main/resources/application.yml
@@ -31,7 +31,7 @@ springdoc:
 
 azure:
   cosmosdb:
-    uri: https://amido-stacks-dev-eun-java-api.documents.azure.com:443/
+    uri: https://localhost:8081
     database: Stacks
     key: xxxxxx
   application-insights:


### PR DESCRIPTION
Removing cosmos db url and upgrade libraries 

#### 📲 What

Changed the Cosmos DB url to be Cosmos Emulator url by default. 
Also updated some of the library version used in this branch to match with the changes made by dependabot in the master branch (The libraries for the master -- https://github.com/amido/stacks-java/pull/237)

#### 🤔 Why

When people download this project or create this project using Scaffolding CLI they wouldn't have the cosmos db url used by the team.
So this branch and master branch uses the same version of the libraries

#### 🛠 How

Changed the cosmos db url in the application.yml file
Updated the version in pom.xml

#### 👀 Evidence

Screenshots / external resources / links / etc.
Link to documentation updated with changes impacted in the PR

#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
