### PR TITLE
fix: No longer register the Pod Identity preview

### DIFF
--- a/build/azDevOps/azure/templates/steps/deploy/deploy-infra.yml
+++ b/build/azDevOps/azure/templates/steps/deploy/deploy-infra.yml
@@ -34,13 +34,6 @@ steps:
 
   - task: Bash@3
     inputs:
-      filePath: "${{ parameters.pipeline_scripts_directory }}/util-azure-register-pod-identity.bash"
-    target:
-      container: ${{ parameters.docker_terraform_container }}
-    displayName: "Register Pod Identity Previews"
-
-  - task: Bash@3
-    inputs:
       filePath: "${{ parameters.pipeline_scripts_directory }}/deploy-azure-terraform-init.bash"
       arguments: >
         -a "${{ parameters.terraform_backend_azure_client_id }}"


### PR DESCRIPTION
Pod Identity is in preview, plus apps shouldn't register this it should be the cluster that does, so removing this for now.