### PR TITLE
[3298] Update other builds to use new subscription

### DIFF
--- a/build/azDevOps/azure/azure-pipelines-javaspring-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-javaspring-k8s.yml
@@ -495,7 +495,7 @@ stages:
 
   - stage: Prod
     dependsOn: Build
-    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+    # condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     variables:
       - group: amido-stacks-infra-credentials-prod
       - group: stacks-credentials-prod-kv

--- a/build/azDevOps/azure/azure-pipelines-javaspring-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-javaspring-k8s.yml
@@ -495,7 +495,7 @@ stages:
 
   - stage: Prod
     dependsOn: Build
-    # condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     variables:
       - group: amido-stacks-infra-credentials-prod
       - group: stacks-credentials-prod-kv

--- a/build/azDevOps/azure/azure-pipelines-javaspring-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-javaspring-k8s.yml
@@ -71,8 +71,8 @@ variables:
   self_pipeline_repo: "$(Agent.BuildDirectory)/s/stacks-pipeline-templates"
   self_pipeline_scripts_dir: "$(self_pipeline_repo)/scripts"
   # TF STATE CONFIG
-  tf_state_rg: "amido-stacks-rg-uks"
-  tf_state_storage: "amidostackstfstategbl"
+  tf_state_rg: "Stacks-Ancillary-Resources"
+  tf_state_storage: "amidostackstfstate"
   tf_state_container: "tfstate"
   # Stacks operates Terraform states based on workspaces **IT IS VERY IMPORTANT** that you ensure a unique name for each application definition
   # Furthermore **IT IS VERY IMPORTANT** that you change the name of a workspace for each deployment stage

--- a/build/azDevOps/azure/azure-pipelines-javaspring-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-javaspring-k8s.yml
@@ -500,7 +500,7 @@ stages:
       - group: amido-stacks-infra-credentials-prod
       - group: stacks-credentials-prod-kv
       - name: prod_azure_client_id
-        value: $[variables.azureclient-id]
+        value: $[variables.azure-client-id]
       - name: prod_azure_client_secret
         value: $[variables.azure-client-secret]
       - name: prod_azure_tenant_id

--- a/build/azDevOps/azure/azure-pipelines-javaspring-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-javaspring-k8s.yml
@@ -244,10 +244,10 @@ stages:
               docker_image_tag: "${{ variables.docker_image_tag }}"
               docker_container_registry_name: "${{ variables.docker_container_registry_name_nonprod }}"
               # Azure
-              azure_client_id: "$(AZURE_CLIENT_ID)"
-              azure_client_secret: "$(AZURE_CLIENT_SECRET)"
-              azure_tenant_id: "$(AZURE_TENANT_ID)"
-              azure_subscription_id: "$(AZURE_SUBSCRIPTION_ID)"
+              azure_client_id: "$(azure-client-id)"
+              azure_client_secret: "$(azure-client-secret)"
+              azure_tenant_id: "$(azure-tenant-id)"
+              azure_subscription_id: "$(azure-subscription-id)"
 
           # Post build tasks, such as Test and Coverage upload, and publishing artefacts
           - template: templates/steps/build/post-build-tasks.yml
@@ -329,19 +329,19 @@ stages:
                     pipeline_scripts_directory: "${{ variables.self_pipeline_scripts_dir }}"
                     docker_terraform_container: "terraform_custom"
                     # Azure Credenitals (For Deploying)
-                    azure_client_id: "$(azure_client_id)"
-                    azure_client_secret: "$(azure_client_secret)"
-                    azure_tenant_id: "$(azure_tenant_id)"
-                    azure_subscription_id: "$(azure_subscription_id)"
+                    azure_client_id: "$(azure-client-id)"
+                    azure_client_secret: "$(azure-client-secret)"
+                    azure_tenant_id: "$(azure-tenant-id)"
+                    azure_subscription_id: "$(azure-subscription-id)"
                     # Terraform
                     terraform_directory: '$(self_repo_tf_dir)'
                     # Backend Azure State Storage Credentials
                     # Change these if your state storage is in a different
                     # location to your deployment
-                    terraform_backend_azure_client_id: "$(azure_client_id)"
-                    terraform_backend_azure_client_secret: "$(azure_client_secret)"
-                    terraform_backend_azure_tenant_id: "$(azure_tenant_id)"
-                    terraform_backend_azure_subscription_id: "$(azure_subscription_id)"
+                    terraform_backend_azure_client_id: "$(azure-client-id)"
+                    terraform_backend_azure_client_secret: "$(azure-client-secret)"
+                    terraform_backend_azure_tenant_id: "$(azure-tenant-id)"
+                    terraform_backend_azure_subscription_id: "$(azure-subscription-id)"
                     terraform_state_rg: ${{ variables.tf_state_rg }}
                     terraform_state_storage: ${{ variables.tf_state_storage }}
                     terraform_state_container: ${{ variables.tf_state_container }}
@@ -456,10 +456,10 @@ stages:
                         additional_args: "-no-empty",
                       },
                     ]
-                    azure_client_id: "$(azure_client_id)"
-                    azure_client_secret: "$(azure_client_secret)"
-                    azure_tenant_id: "$(azure_tenant_id)"
-                    azure_subscription_id: "$(azure_subscription_id)"
+                    azure_client_id: "$(azure-client-id)"
+                    azure_client_secret: "$(azure-client-secret)"
+                    azure_tenant_id: "$(azure-tenant-id)"
+                    azure_subscription_id: "$(azure-subscription-id)"
                     aks_cluster_resourcegroup: "${{ variables.aks_cluster_resourcegroup }}"
                     aks_cluster_name: "${{ variables.aks_cluster_name }}"
                     # Used to do a `kubectl rollout status`
@@ -500,13 +500,13 @@ stages:
       - group: amido-stacks-infra-credentials-prod
       - group: stacks-credentials-prod-kv
       - name: prod_azure_client_id
-        value: $[variables.azure_client_id]
+        value: $[variables.azureclient-id]
       - name: prod_azure_client_secret
-        value: $[variables.azure_client_secret]
+        value: $[variables.azure-client-secret]
       - name: prod_azure_tenant_id
-        value: $[variables.azure_tenant_id]
+        value: $[variables.azure-tenant-id]
       - name: prod_azure_subscription_id
-        value: $[variables.azure_subscription_id]
+        value: $[variables.azure-subscription-id]
       - group: amido-stacks-java-api
       - name: dns_name
         value: "$(Environment.ShortName)-java-api"
@@ -624,13 +624,13 @@ stages:
           - group: amido-stacks-infra-credentials-prod
           - group: stacks-credentials-prod-kv
           - name: prod_azure_client_id
-            value: $[variables.azure_client_id]
+            value: $[variables.azure-client-id]
           - name: prod_azure_client_secret
-            value: $[variables.azure_client_secret]
+            value: $[variables.azure-client-secret]
           - name: prod_azure_tenant_id
-            value: $[variables.azure_tenant_id]
+            value: $[variables.azure-tenant-id]
           - name: prod_azure_subscription_id
-            value: $[variables.azure_subscription_id]
+            value: $[variables.azure-subscription-id]
           - group: stacks-credentials-nonprod-kv
         strategy:
           runOnce:
@@ -646,10 +646,10 @@ stages:
                     arguments: >
                       -a "$(docker_image_name):$(docker_image_tag)"
                       -b "$(k8s_docker_registry_nonprod)"
-                      -c "$(azure_subscription_id)"
-                      -d "$(azure_client_id)"
-                      -e "$(azure_client_secret)"
-                      -f "$(azure_tenant_id)"
+                      -c "$(azure-subscription-id)"
+                      -d "$(azure-client-id)"
+                      -e "$(azure-client-secret)"
+                      -f "$(azure-tenant-id)"
                       -g "$(k8s_docker_registry_prod)"
                       -h "$(prod_azure_subscription_id)"
                       -i "$(prod_azure_client_id)"

--- a/build/azDevOps/azure/azure-pipelines-javaspring-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-javaspring-k8s.yml
@@ -506,7 +506,7 @@ stages:
       - name: prod_azure_tenant_id
         value: $[variables.azure_tenant_id]
       - name: prod_azure_subscription_id
-        value: $[variables.azure_subscription_id]                       
+        value: $[variables.azure_subscription_id]                    
       - group: amido-stacks-java-api
       - name: dns_name
         value: "$(Environment.ShortName)-java-api"
@@ -630,7 +630,7 @@ stages:
           - name: prod_azure_tenant_id
             value: $[variables.azure_tenant_id]
           - name: prod_azure_subscription_id
-            value: $[variables.azure_subscription_id] 
+            value: $[variables.azure_subscription_id]
           - group: stacks-credentials-nonprod-kv
         strategy:
           runOnce:

--- a/build/azDevOps/azure/azure-pipelines-javaspring-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-javaspring-k8s.yml
@@ -103,9 +103,9 @@ variables:
   build_artifact_deploy_path: "${{ variables.self_repo_dir }}/deploy/k8s/app"
   build_artifact_deploy_name: "${{ variables.self_generic_name }}"
   # DEFAULT IMAGE RUNNER
-  pool_vm_image: ubuntu-18.04
+  pool_vm_image: ubuntu-20.04
   # Infra
-  region: "northeurope"
+  region: "westeurope"
   base_domain_nonprod: nonprod.amidostacks.com
   base_domain_internal_nonprod: nonprod.amidostacks.internal
   base_domain_prod: prod.amidostacks.com
@@ -140,6 +140,7 @@ stages:
     variables:
       # You can find notes in the READMEs around which values to use for each ENV variable group
       - group: amido-stacks-infra-credentials-nonprod
+      - group: stacks-credentials-nonprod-kv
       - group: amido-stacks-java-api
     jobs:
       - job: ApiBuild
@@ -272,6 +273,7 @@ stages:
     condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
     variables:
       - group: amido-stacks-infra-credentials-nonprod
+      - group: stacks-credentials-nonprod-kv
       - group: amido-stacks-java-api
       - name: dns_name
         value: "$(Environment.ShortName)-java-api"
@@ -496,11 +498,20 @@ stages:
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     variables:
       - group: amido-stacks-infra-credentials-prod
+      - group: stacks-credentials-prod-kv
+      - name: prod_azure_client_id
+        value: $[variables.azure_client_id]
+      - name: prod_azure_client_secret
+        value: $[variables.azure_client_secret]
+      - name: prod_azure_tenant_id
+        value: $[variables.azure_tenant_id]
+      - name: prod_azure_subscription_id
+        value: $[variables.azure_subscription_id]                       
       - group: amido-stacks-java-api
       - name: dns_name
         value: "$(Environment.ShortName)-java-api"
       - name: core_resource_group
-        value: "amido-stacks-prod-eun-core"
+        value: "amido-stacks-prod-euw-core"
       - name: Environment.ShortName
         value: prod
     jobs:
@@ -511,9 +522,9 @@ stages:
         environment: ${{ variables.domain }}-prod
         variables:
           - name: app_insights_name
-            value: "amido-stacks-prod-eun-core"
+            value: "amido-stacks-prod-euw-core"
           - name: app_gateway_frontend_ip_name
-            value: "amido-stacks-prod-eun-core"
+            value: "amido-stacks-prod-euw-core"
           - name: attributes
             value: "[]"
           - name: tags
@@ -611,6 +622,16 @@ stages:
         variables:
           - group: amido-stacks-infra-credentials-nonprod
           - group: amido-stacks-infra-credentials-prod
+          - group: stacks-credentials-prod-kv
+          - name: prod_azure_client_id
+            value: $[variables.azure_client_id]
+          - name: prod_azure_client_secret
+            value: $[variables.azure_client_secret]
+          - name: prod_azure_tenant_id
+            value: $[variables.azure_tenant_id]
+          - name: prod_azure_subscription_id
+            value: $[variables.azure_subscription_id] 
+          - group: stacks-credentials-nonprod-kv
         strategy:
           runOnce:
             deploy:
@@ -667,7 +688,7 @@ stages:
           - name: aks_cluster_resourcegroup
             value: "${{ variables.core_resource_group }}"
           - name: aks_cluster_name
-            value: "amido-stacks-prod-eun-core"
+            value: "amido-stacks-prod-euw-core"
           - name: app_name
             value: "java-api"
         strategy:

--- a/build/azDevOps/azure/azure-pipelines-javaspring-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-javaspring-k8s.yml
@@ -506,7 +506,7 @@ stages:
       - name: prod_azure_tenant_id
         value: $[variables.azure_tenant_id]
       - name: prod_azure_subscription_id
-        value: $[variables.azure_subscription_id]                    
+        value: $[variables.azure_subscription_id]
       - group: amido-stacks-java-api
       - name: dns_name
         value: "$(Environment.ShortName)-java-api"

--- a/build/azDevOps/azure/azure-pipelines-javaspring-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-javaspring-k8s.yml
@@ -82,6 +82,9 @@ variables:
   # avoid running anything past dev that is not on master
   # sample value: company-webapp
   tf_state_key: "stacks-api-java"
+  # Environment
+  # Name of the resource group for DNS
+  dns_zone_resource_group: "Stacks-Ancillary-Resources"
   # Versioning
   version_major: 0
   version_minor: 0
@@ -297,7 +300,7 @@ stages:
           - name: app_gateway_frontend_ip_name
             value: "amido-stacks-nonprod-euw-core"
           - name: dns_zone_resource_group
-            value: "Stacks-Ancillary-Resources"
+            value: "$(dns_zone_resource_group)"
           - name: create_cosmosdb
             value: true
           - name: create_cache
@@ -524,7 +527,7 @@ stages:
           - name: resource_group_location
             value: "$(region)"
           - name: dns_zone_resource_group
-            value: "Stacks-Ancillary-Resources"
+            value: "$(dns_zone_resource_group)"
           - name: create_cosmosdb
             value: true
           - name: create_cache

--- a/build/azDevOps/azure/azure-pipelines-javaspring-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-javaspring-k8s.yml
@@ -299,8 +299,6 @@ stages:
             value: "$(region)"
           - name: app_gateway_frontend_ip_name
             value: "amido-stacks-nonprod-euw-core"
-          - name: dns_zone_resource_group
-            value: "$(dns_zone_resource_group)"
           - name: create_cosmosdb
             value: true
           - name: create_cache
@@ -526,8 +524,6 @@ stages:
             value: "{}"
           - name: resource_group_location
             value: "$(region)"
-          - name: dns_zone_resource_group
-            value: "$(dns_zone_resource_group)"
           - name: create_cosmosdb
             value: true
           - name: create_cache

--- a/build/azDevOps/azure/azure-pipelines-javaspring-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-javaspring-k8s.yml
@@ -297,7 +297,7 @@ stages:
           - name: app_gateway_frontend_ip_name
             value: "amido-stacks-nonprod-euw-core"
           - name: dns_zone_resource_group
-            value: ""
+            value: "Stacks-Ancillary-Resources"
           - name: create_cosmosdb
             value: true
           - name: create_cache
@@ -532,7 +532,7 @@ stages:
           - name: resource_group_location
             value: "$(region)"
           - name: dns_zone_resource_group
-            value: ""
+            value: "Stacks-Ancillary-Resources"
           - name: create_cosmosdb
             value: true
           - name: create_cache

--- a/build/azDevOps/azure/azure-pipelines-javaspring-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-javaspring-k8s.yml
@@ -499,14 +499,6 @@ stages:
     variables:
       - group: amido-stacks-infra-credentials-prod
       - group: stacks-credentials-prod-kv
-      - name: prod_azure_client_id
-        value: $[variables.azure-client-id]
-      - name: prod_azure_client_secret
-        value: $[variables.azure-client-secret]
-      - name: prod_azure_tenant_id
-        value: $[variables.azure-tenant-id]
-      - name: prod_azure_subscription_id
-        value: $[variables.azure-subscription-id]
       - group: amido-stacks-java-api
       - name: dns_name
         value: "$(Environment.ShortName)-java-api"
@@ -562,19 +554,19 @@ stages:
                     pipeline_scripts_directory: "${{ variables.self_pipeline_scripts_dir }}"
                     docker_terraform_container: "terraform_custom"
                     # Azure Credenitals (For Deploying)
-                    azure_client_id: "$(prod_azure_client_id)"
-                    azure_client_secret: "$(prod_azure_client_secret)"
-                    azure_tenant_id: "$(prod_azure_tenant_id)"
-                    azure_subscription_id: "$(prod_azure_subscription_id)"
+                    azure_client_id: "$(prod-azure-client-id)"
+                    azure_client_secret: "$(prod-azure-client-secret)"
+                    azure_tenant_id: "$(prod-azure-tenant-id)"
+                    azure_subscription_id: "$(prod-azure-subscription-id)"
                     # Terraform
                     terraform_directory: '$(self_repo_tf_dir)'
                     # Backend Azure State Storage Credentials
                     # Change these if your state storage is in a different
                     # location to your deployment
-                    terraform_backend_azure_client_id: "$(prod_azure_client_id)"
-                    terraform_backend_azure_client_secret: "$(prod_azure_client_secret)"
-                    terraform_backend_azure_tenant_id: "$(prod_azure_tenant_id)"
-                    terraform_backend_azure_subscription_id: "$(prod_azure_subscription_id)"
+                    terraform_backend_azure_client_id: "$(prod-azure-client-id)"
+                    terraform_backend_azure_client_secret: "$(prod-azure-client-secret)"
+                    terraform_backend_azure_tenant_id: "$(prod-azure-tenant-id)"
+                    terraform_backend_azure_subscription_id: "$(prod-azure-subscription-id)"
                     terraform_state_rg: ${{ variables.tf_state_rg }}
                     terraform_state_storage: ${{ variables.tf_state_storage }}
                     terraform_state_container: ${{ variables.tf_state_container }}
@@ -623,14 +615,6 @@ stages:
           - group: amido-stacks-infra-credentials-nonprod
           - group: amido-stacks-infra-credentials-prod
           - group: stacks-credentials-prod-kv
-          - name: prod_azure_client_id
-            value: $[variables.azure-client-id]
-          - name: prod_azure_client_secret
-            value: $[variables.azure-client-secret]
-          - name: prod_azure_tenant_id
-            value: $[variables.azure-tenant-id]
-          - name: prod_azure_subscription_id
-            value: $[variables.azure-subscription-id]
           - group: stacks-credentials-nonprod-kv
         strategy:
           runOnce:
@@ -651,10 +635,10 @@ stages:
                       -e "$(azure-client-secret)"
                       -f "$(azure-tenant-id)"
                       -g "$(k8s_docker_registry_prod)"
-                      -h "$(prod_azure_subscription_id)"
-                      -i "$(prod_azure_client_id)"
-                      -j "$(prod_azure_client_secret)"
-                      -k "$(prod_azure_tenant_id)"
+                      -h "$(prod-azure-subscription-id)"
+                      -i "$(prod-azure-client-id)"
+                      -j "$(prod-azure-client-secret)"
+                      -k "$(prod-azure-tenant-id)"
                       -Z "false"
                   displayName: Promote Docker Image to Production ACR
 
@@ -735,10 +719,10 @@ stages:
                         additional_args: "-no-empty",
                       },
                     ]
-                    azure_client_id: "$(prod_azure_client_id)"
-                    azure_client_secret: "$(prod_azure_client_secret)"
-                    azure_tenant_id: "$(prod_azure_tenant_id)"
-                    azure_subscription_id: "$(prod_azure_subscription_id)"
+                    azure_client_id: "$(prod-azure-client-id)"
+                    azure_client_secret: "$(prod-azure-client-secret)"
+                    azure_tenant_id: "$(prod-azure-tenant-id)"
+                    azure_subscription_id: "$(prod-azure-subscription-id)"
                     aks_cluster_resourcegroup: "${{ variables.aks_cluster_resourcegroup }}"
                     aks_cluster_name: "${{ variables.aks_cluster_name }}"
                     # Used to do a `kubectl rollout status`

--- a/build/azDevOps/azure/azure-pipelines-javaspring-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-javaspring-k8s.yml
@@ -94,10 +94,10 @@ variables:
   docker_dockerfile_path: "."
   docker_image_name: "$(self_generic_name)"
   docker_image_tag: "${{ variables.version_major }}.${{ variables.version_minor }}.$(version_revision)-$(Build.SourceBranchName)"
-  docker_container_registry_name_nonprod: amidostacksnonprodeuncore
+  docker_container_registry_name_nonprod: amidostacksnonprodeuwcore
   docker_java_image: "azul_java"
   k8s_docker_registry_nonprod: "${{ variables.docker_container_registry_name_nonprod }}.azurecr.io"
-  docker_container_registry_name_prod: amidostacksprodeuncore
+  docker_container_registry_name_prod: amidostacksprodeuwcore
   k8s_docker_registry_prod: "${{ variables.docker_container_registry_name_prod }}.azurecr.io"
   # BUILD ARTIFACTS across stages
   build_artifact_deploy_path: "${{ variables.self_repo_dir }}/deploy/k8s/app"
@@ -278,7 +278,7 @@ stages:
       - name: dns_name
         value: "$(Environment.ShortName)-java-api"
       - name: core_resource_group
-        value: "amido-stacks-nonprod-eun-core"
+        value: "amido-stacks-nonprod-euw-core"
       - name: Environment.ShortName
         value: dev
     jobs:
@@ -295,7 +295,7 @@ stages:
           - name: resource_group_location
             value: "$(region)"
           - name: app_gateway_frontend_ip_name
-            value: "amido-stacks-nonprod-eun-core"
+            value: "amido-stacks-nonprod-euw-core"
           - name: dns_zone_resource_group
             value: ""
           - name: create_cosmosdb
@@ -315,7 +315,7 @@ stages:
           - name: cosmosdb_offer_type
             value: "Standard"
           - name: app_insights_name
-            value: "amido-stacks-nonprod-eun-core"
+            value: "amido-stacks-nonprod-euw-core"
         strategy:
           runOnce:
             deploy:
@@ -408,7 +408,7 @@ stages:
           - name: aks_cluster_resourcegroup
             value: "${{ variables.core_resource_group }}"
           - name: aks_cluster_name
-            value: "amido-stacks-nonprod-eun-core"
+            value: "amido-stacks-nonprod-euw-core"
           - name: app_name
             value: "java-api"
         strategy:


### PR DESCRIPTION
#### 📲 What

Change the build pipeline file to work with the new subscription and cluster

#### 🤔 Why

The current subscription for stacks is running an out-of-date version of AKS. Additionally there are issues with the subscription to do with billing.
A new subscription has been created and new AKS clusters deployed.

#### 🛠 How

Modified the location of the resources to `westeurope` (this was done to avoid name conflicts)
Set the resource group that contains the DNS zones to be updated
Set the tasks to use the secrets from the two Azure Key Vaults we have in plave

#### 👀 Evidence

This has been tested in the branch and all builds and deployments are running as before, but into the new subsciption and cluster..

#### 🕵️ How to test

The build has tests that are being run and are passing

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
