### PR TITLE
Feature/4976-aws-tests

### DIFF
--- a/api-tests-karate/src/test/java/components/cloud/CheckAwsFeature.feature
+++ b/api-tests-karate/src/test/java/components/cloud/CheckAwsFeature.feature
@@ -1,0 +1,10 @@
+@AWS
+Feature: Check whether AWS features are operational
+  The `/v1/secrets` endpoint returns a few example secrets to enable us to verify the connection
+
+  Scenario: Example Secrets endpoint
+    Given url base_url.concat(secrets)
+    And header Authorization = auth.bearer_token
+    When method GET
+    Then status 200
+    * match $ == "Secrets -> SECRET-VALUE-1, SECRET-VALUE-2, SECRET-VALUE-3, SECRET-VALUE-4"

--- a/api-tests-karate/src/test/java/components/cloud/CheckAwsFeature.feature
+++ b/api-tests-karate/src/test/java/components/cloud/CheckAwsFeature.feature
@@ -1,4 +1,4 @@
-@AWS
+@AWS @Ignore
 Feature: Check whether AWS features are operational
   The `/v1/secrets` endpoint returns a few example secrets to enable us to verify the connection
 

--- a/api-tests-karate/src/test/java/karate-config.js
+++ b/api-tests-karate/src/test/java/karate-config.js
@@ -13,6 +13,7 @@ function fn() {
         menu: '/v1/menu',
         menu_v2: '/v2/menu',
         items: '/items',
+        secrets: '/v1/secrets',
 
         generate_auth0_token: false,
 

--- a/api-tests/src/test/java/com/amido/stacks/tests/api/WebServiceEndPoints.java
+++ b/api-tests/src/test/java/com/amido/stacks/tests/api/WebServiceEndPoints.java
@@ -6,7 +6,8 @@ public enum WebServiceEndPoints {
   STATUS("/health"),
   MENU("/v1/menu"),
   MENU_V2("/v2/menu"),
-  ITEMS("/items");
+  ITEMS("/items"),
+  SECRETS("/v1/secrets");
 
   private final String url;
 

--- a/api-tests/src/test/java/com/amido/stacks/tests/api/cloud/AwsFeaturesStatus.java
+++ b/api-tests/src/test/java/com/amido/stacks/tests/api/cloud/AwsFeaturesStatus.java
@@ -8,7 +8,8 @@ public class AwsFeaturesStatus {
 
   final String BASE_URL = WebServiceEndPoints.BASE_URL.getUrl();
 
-  public String expectedExampleSecrets = "Secrets -> SECRET-VALUE-1, SECRET-VALUE-2, SECRET-VALUE-3, SECRET-VALUE-4";
+  public String expectedExampleSecrets =
+      "Secrets -> SECRET-VALUE-1, SECRET-VALUE-2, SECRET-VALUE-3, SECRET-VALUE-4";
 
   @Step("Get current example secrets")
   public void readExampleSecrets() {

--- a/api-tests/src/test/java/com/amido/stacks/tests/api/cloud/AwsFeaturesStatus.java
+++ b/api-tests/src/test/java/com/amido/stacks/tests/api/cloud/AwsFeaturesStatus.java
@@ -1,0 +1,17 @@
+package com.amido.stacks.tests.api.cloud;
+
+import com.amido.stacks.tests.api.WebServiceEndPoints;
+import net.serenitybdd.rest.SerenityRest;
+import net.thucydides.core.annotations.Step;
+
+public class AwsFeaturesStatus {
+
+  final String BASE_URL = WebServiceEndPoints.BASE_URL.getUrl();
+
+  public String expectedExampleSecrets = "Secrets -> SECRET-VALUE-1, SECRET-VALUE-2, SECRET-VALUE-3, SECRET-VALUE-4";
+
+  @Step("Get current example secrets")
+  public void readExampleSecrets() {
+    SerenityRest.get(BASE_URL + WebServiceEndPoints.SECRETS.getUrl());
+  }
+}

--- a/api-tests/src/test/java/com/amido/stacks/tests/api/stepdefinitions/AwsStepDefinitions.java
+++ b/api-tests/src/test/java/com/amido/stacks/tests/api/stepdefinitions/AwsStepDefinitions.java
@@ -1,12 +1,12 @@
 package com.amido.stacks.tests.api.stepdefinitions;
 
+import static net.serenitybdd.rest.SerenityRest.restAssuredThat;
+import static org.hamcrest.Matchers.equalTo;
+
 import com.amido.stacks.tests.api.cloud.AwsFeaturesStatus;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import net.thucydides.core.annotations.Steps;
-
-import static net.serenitybdd.rest.SerenityRest.restAssuredThat;
-import static org.hamcrest.Matchers.equalTo;
 
 public class AwsStepDefinitions {
 
@@ -19,7 +19,7 @@ public class AwsStepDefinitions {
 
   @Then("the API should return the correct examples")
   public void the_API_should_return() {
-    restAssuredThat(lastResponse -> lastResponse.body(equalTo(AwsFeaturesStatus.expectedExampleSecrets)));
+    restAssuredThat(
+        lastResponse -> lastResponse.body(equalTo(AwsFeaturesStatus.expectedExampleSecrets)));
   }
-
 }

--- a/api-tests/src/test/java/com/amido/stacks/tests/api/stepdefinitions/AwsStepDefinitions.java
+++ b/api-tests/src/test/java/com/amido/stacks/tests/api/stepdefinitions/AwsStepDefinitions.java
@@ -1,0 +1,25 @@
+package com.amido.stacks.tests.api.stepdefinitions;
+
+import com.amido.stacks.tests.api.cloud.AwsFeaturesStatus;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import net.thucydides.core.annotations.Steps;
+
+import static net.serenitybdd.rest.SerenityRest.restAssuredThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class AwsStepDefinitions {
+
+  @Steps AwsFeaturesStatus AwsFeaturesStatus;
+
+  @When("I check the example secrets")
+  public void check_the_example_secrets() {
+    AwsFeaturesStatus.readExampleSecrets();
+  }
+
+  @Then("the API should return the correct examples")
+  public void the_API_should_return() {
+    restAssuredThat(lastResponse -> lastResponse.body(equalTo(AwsFeaturesStatus.expectedExampleSecrets)));
+  }
+
+}

--- a/api-tests/src/test/resources/cucumber/features/cloud/CheckAwsFeature.feature
+++ b/api-tests/src/test/resources/cucumber/features/cloud/CheckAwsFeature.feature
@@ -1,4 +1,4 @@
-@AWS
+@AWS @Ignore
 Feature: Check whether AWS features are operational
   The `/v1/secrets` endpoint returns a few example secrets to enable us to verify the connection
 

--- a/api-tests/src/test/resources/cucumber/features/cloud/CheckAwsFeature.feature
+++ b/api-tests/src/test/resources/cucumber/features/cloud/CheckAwsFeature.feature
@@ -1,0 +1,8 @@
+@AWS
+Feature: Check whether AWS features are operational
+  The `/v1/secrets` endpoint returns a few example secrets to enable us to verify the connection
+
+  Scenario: Example Secrets endpoint
+    Given the application is running
+    When I check the example secrets
+    Then the API should return the correct examples


### PR DESCRIPTION
[4976-Verify Secrets] Adding Serenity and Karate tests to check the AWS Secrets connectivity by hitting the example endpoint. 