### PR TITLE
Remove Karate as it is no longer a tool/framework supported by Stacks

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -29,7 +29,7 @@
     <azure.springboot.version>4.0.0</azure.springboot.version>
     <au.com.dius.pact-jvm-provider-spring.version>4.0.10</au.com.dius.pact-jvm-provider-spring.version>
     <au.com.dius.pact.consumer-version>4.6.14</au.com.dius.pact.consumer-version>
-    <au.com.dius.pact.provider.maven-version>4.2.7</au.com.dius.pact.provider.maven-version>
+    <au.com.dius.pact.provider.maven-version>4.6.14</au.com.dius.pact.provider.maven-version>
     <aws-java-sdk-s3.version>1.12.773</aws-java-sdk-s3.version>
     <aspectjweaver.version>1.9.9.1</aspectjweaver.version>
     <exec-maven-plugin.version>3.4.1</exec-maven-plugin.version>


### PR DESCRIPTION
[8175 - Remove Karate from stacks-java](https://amido-dev.visualstudio.com/Amido-Stacks/_workitems/edit/8175)

#### 📲 What

Removed all code relating to the Karate tests

#### 🤔 Why

We have internally decided that Karate is no longer the tool of choice for API testing in Stacks. We will be moving to RestAssured

#### 🛠 How

Deleting test folder and removing references to the test folder and tests from other scripts

#### 👀 Evidence


#### 🕵️ How to test

