### PR TITLE
ci(): configure dependabot (PR & Group)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,16 @@ updates:
       interval: weekly
       day: monday
       timezone: Europe/London
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 50
     assignees:
       - steveclewer
     rebase-strategy: disabled
+    groups:
+      low-risk:
+        applies-to: version-updates
+        update-types:
+        - "minor"
+        - "patch"
 
   - package-ecosystem: npm
     directory: "/build/azDevOps/azure/coverage"
@@ -17,10 +23,16 @@ updates:
       interval: weekly
       day: monday
       timezone: Europe/London
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 50
     assignees:
       - ElvenSpellmaker
     rebase-strategy: disabled
+    groups:
+      low-risk:
+        applies-to: version-updates
+        update-types:
+        - "minor"
+        - "patch"
 
   - package-ecosystem: maven
     directory: "/api-tests"
@@ -28,10 +40,16 @@ updates:
       interval: weekly
       day: monday
       timezone: Europe/London
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 50
     assignees:
       - VitalinaVZdrobau
     rebase-strategy: disabled
+    groups:
+      low-risk:
+        applies-to: version-updates
+        update-types:
+        - "minor"
+        - "patch"
 
   - package-ecosystem: terraform
     directory: "/deploy/azure/app/kube"
@@ -39,7 +57,13 @@ updates:
       interval: weekly
       day: monday
       timezone: Europe/London
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 50
     assignees:
       - ElvenSpellmaker
     rebase-strategy: disabled
+    groups:
+      low-risk:
+        applies-to: version-updates
+        update-types:
+        - "minor"
+        - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,8 @@ updates:
       low-risk:
         applies-to: version-updates
         update-types:
-        - "minor"
-        - "patch"
+          - "minor"
+          - "patch"
 
   - package-ecosystem: npm
     directory: "/build/azDevOps/azure/coverage"
@@ -31,8 +31,8 @@ updates:
       low-risk:
         applies-to: version-updates
         update-types:
-        - "minor"
-        - "patch"
+          - "minor"
+          - "patch"
 
   - package-ecosystem: maven
     directory: "/api-tests"
@@ -48,8 +48,8 @@ updates:
       low-risk:
         applies-to: version-updates
         update-types:
-        - "minor"
-        - "patch"
+          - "minor"
+          - "patch"
 
   - package-ecosystem: terraform
     directory: "/deploy/azure/app/kube"
@@ -65,5 +65,5 @@ updates:
       low-risk:
         applies-to: version-updates
         update-types:
-        - "minor"
-        - "patch"
+          - "minor"
+          - "patch"


### PR DESCRIPTION
#### 📲 What

- configures dependabot to offer 50 PRs per week rather than 10
- groups low-risk dependency updates (i.e. patch and minor)

#### 🤔 Why

The current pace of ten PRs/week is too low to get on on top of software currency efforts within stacks; additionally opening a PR-per-update is laborious compared to batching multiple updates together.

#### 🛠 How

Dependabot configuration has been updated to allow for 50 PRs per week, this is up from the current 10 PRs per week which itself is up from the default of 5.

PRs are [grouped](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) if they match the `minor` or `patch` update types, i.e. if they are `1.0.0` → `1.0.1` or  `1.0.0` → `1.1.0` then they will be grouped. Breaking changes however (i.e. `1.0.0` → `2.0.0`) are not grouped at all.

#### 👀 Evidence

Screenshots / external resources / links / etc.
Link to documentation updated with changes impacted in the PR

#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Passing all automated tests, including a successful deployment?
- [X] Rebased/merged with latest changes from development and re-tested?
