### PR TITLE
Bump vulnerable Netty and HttpClient test dependencies

### DIFF
--- a/api-tests/pom.xml
+++ b/api-tests/pom.xml
@@ -39,10 +39,10 @@
     <springfox.swagger-ui.version>3.0.0</springfox.swagger-ui.version>
     <guava.version>33.5.0-jre</guava.version>
     <json.version>20250517</json.version>
-    <netty.codec.http.version>4.2.10.Final</netty.codec.http.version>
-    <netty.codec.http2.version>4.2.10.Final</netty.codec.http2.version>
-    <netty.transport.native.epoll.version>4.2.10.Final</netty.transport.native.epoll.version>
-    <httpclient5.version>5.6</httpclient5.version>
+    <netty.codec.http.version>4.2.13.Final</netty.codec.http.version>
+    <netty.codec.http2.version>4.2.13.Final</netty.codec.http2.version>
+    <netty.transport.native.epoll.version>4.2.13.Final</netty.transport.native.epoll.version>
+    <httpclient5.version>5.6.1</httpclient5.version>
     <xerces.version>2.12.2</xerces.version>
     <commons.codec.version>1.21.0</commons.codec.version>
     <spring.web.version>6.2.9</spring.web.version>


### PR DESCRIPTION
#### 📲 What

Bumps the directly pinned Netty and Apache HttpClient5 versions in the api-tests Maven module to the first patched releases flagged by Dependabot.

#### 🤔 Why

Dependabot has open alerts for Netty and Apache HttpClient5 in api-tests/pom.xml. The current pinned versions resolve to vulnerable releases.

#### 🛠 How

Updated the api-tests dependency properties only:
- netty-codec-http to 4.2.13.Final
- netty-codec-http2 to 4.2.13.Final
- netty-transport-native-epoll to 4.2.13.Final
- httpclient5 to 5.6.1

This keeps the change limited to the affected test module and avoids broader dependency churn.

#### 👀 Evidence

- Dependabot alerts retrieved with gh for Ensono/stacks-java identified api-tests/pom.xml as the affected manifest.
- Resolved dependency tree after the change includes io.netty:netty-codec-http:4.2.13.Final, io.netty:netty-codec-http2:4.2.13.Final, io.netty:netty-transport-native-epoll:4.2.13.Final, and org.apache.httpcomponents.client5:httpclient5:5.6.1.
- No documentation impact for this dependency-only change.

#### 🕵️ How to test

cd api-tests && ./mvnw -DskipTests dependency:tree '-Dincludes=io.netty:netty-codec-http,io.netty:netty-codec-http2,io.netty:netty-transport-native-epoll,org.apache.httpcomponents.client5:httpclient5'\ncd api-tests && ./mvnw -q -DskipTests test-compile\n\n#### ✅ Acceptance criteria Checklist\n\n- [ ] Code peer reviewed?\n- [ ] Documentation has been updated to reflect the changes?\n- [ ] Passing all automated tests, including a successful deployment?\n- [ ] Passing any exploratory testing?\n- [ ] Rebased/merged with latest changes from development and re-tested?\n- [x] Meeting the Coding Standards?