### PR TITLE
chore: bump vulnerable `postcss`

### DIFF
--- a/build/azDevOps/azure/coverage/package-lock.json
+++ b/build/azDevOps/azure/coverage/package-lock.json
@@ -6,13 +6,13 @@
     "": {
       "license": "Apache-2.0",
       "devDependencies": {
-        "gulp": "^5.0.1",
-        "gulp-inline-source": "^4.0.0",
-        "gulp-postcss": "^10.0.0",
-        "postcss-image-inliner": "^7.0.1"
+        "gulp": "5.0.1",
+        "gulp-inline-source": "4.0.0",
+        "gulp-postcss": "10.0.0",
+        "postcss-image-inliner": "7.0.1"
       },
       "engines": {
-        "node": ">=20.16.0"
+        "node": ">=24"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2430,7 +2430,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -2740,9 +2739,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.47",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
-      "integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -2761,8 +2760,8 @@
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "nanoid": "^3.3.7",
-        "picocolors": "^1.1.0",
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
       "engines": {
@@ -3859,16 +3858,19 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",
-      "integrity": "sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/build/azDevOps/azure/coverage/package.json
+++ b/build/azDevOps/azure/coverage/package.json
@@ -3,15 +3,16 @@
   "license": "Apache-2.0",
   "repository": "N/A",
   "engines": {
-    "node": ">=20.16.0"
+    "node": ">=24"
   },
   "devDependencies": {
-    "gulp": "^5.0.1",
-    "gulp-inline-source": "^4.0.0",
-    "gulp-postcss": "^10.0.0",
-    "postcss-image-inliner": "^7.0.1"
+    "gulp": "5.0.1",
+    "gulp-inline-source": "4.0.0",
+    "gulp-postcss": "10.0.0",
+    "postcss-image-inliner": "7.0.1"
   },
   "overrides": {
-    "inline-source": "^8.0.3"
+    "inline-source": "^8.0.3",
+    "postcss": "^8.5.10"
   }
 }


### PR DESCRIPTION
#### 📲 What

Updates `postcss` in the coverage util to resolve CVE-2026-41305. Additionally bump runtime to v24.

#### 🤔 Why

As part of our responsibilities under ISO27001, we are required to manage and mitigate risks associated with software vulnerabilities. By enforcing a secure version of Ensono Stacks, we reduce the risk of known vulnerabilities being exploited in our development environment. This proactive approach to dependency management demonstrates our commitment to maintaining the confidentiality, integrity, and availability of our information assets, as required by ISO27001 controls on software development and vulnerability management.

#### 🛠 How

Updated via an override.

#### 👀 Evidence

```
 $ npm ls postcss
coverage@ /home/rslater/source/stacks-java/build/azDevOps/azure/coverage
├─┬ gulp-postcss@10.0.0
│ ├─┬ postcss-load-config@5.1.0
│ │ └── postcss@8.5.14 deduped
│ └── postcss@8.5.14
└─┬ postcss-image-inliner@7.0.1
  └── postcss@8.5.14 deduped
 $ npm audit
found 0 vulnerabilities
```

#### 🕵️ How to test

CI

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [X] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [X] Passing any exploratory testing?
- [X] Rebased/merged with latest changes from development and re-tested?
- [X] Meeting the Coding Standards?
